### PR TITLE
Require delivery photo before submission

### DIFF
--- a/public/assets/js/index.js
+++ b/public/assets/js/index.js
@@ -262,6 +262,16 @@ const app = createApp({
         return;
       }
 
+      if (!state.photoFile && !state.photoPreview) {
+        Toastify({
+          text: t("needWatermarkedPhoto"),
+          duration: 3000,
+          gravity: "bottom",
+          position: "center",
+        }).showToast();
+        return;
+      }
+
       state.submitting = true;
       state.uploadPct = 0;
       state.submitMsg = "";

--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -19,6 +19,7 @@
     "photoTip": "Take or choose from gallery",
     "removePhoto": "Remove Photo",
     "needSelectStatus": "Please select a shipping status",
+    "needWatermarkedPhoto": "Please upload a watermarked delivery photo before submitting.",
     "invalidId": "Invalid DU ID",
     "submit": "Submit",
     "submitting": "Submitting…",

--- a/public/locales/id/index.json
+++ b/public/locales/id/index.json
@@ -19,6 +19,7 @@
     "photoTip": "Dukung kamera atau galeri",
     "removePhoto": "Hapus Foto",
     "needSelectStatus": "Silakan pilih status pengiriman",
+    "needWatermarkedPhoto": "Harap unggah foto penyerahan dengan watermark sebelum mengirim.",
     "invalidId": "ID DU tidak valid",
     "submit": "Kirim",
     "submitting": "Mengirim…",

--- a/public/locales/zh/index.json
+++ b/public/locales/zh/index.json
@@ -19,6 +19,7 @@
     "photoTip": "支持拍照或从相册选择",
     "removePhoto": "移除照片",
     "needSelectStatus": "请先选择运输状态",
+    "needWatermarkedPhoto": "请上传带有水印的交付照片再提交。",
     "invalidId": "无效的DU ID",
     "submit": "提交",
     "submitting": "提交中…",


### PR DESCRIPTION
## Summary
- block submissions on the scan page when no delivery photo is selected
- show a 3-second toast prompting the user to upload a watermarked delivery photo
- translate the delivery photo reminder across supported locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd40903a7c83208febbe87e2a72d3a