### PR TITLE
Resolve merge conflicts with main

### DIFF
--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -19,6 +19,7 @@
     "photoTip": "Take or choose from gallery",
     "removePhoto": "Remove Photo",
     "needSelectStatus": "Please select a shipping status",
+    "needWatermarkedPhoto": "Please upload a watermarked delivery photo before submitting.",
     "invalidId": "Invalid DU ID",
     "submit": "Submit",
     "submitting": "Submitting…",

--- a/public/locales/id/index.json
+++ b/public/locales/id/index.json
@@ -19,6 +19,7 @@
     "photoTip": "Dukung kamera atau galeri",
     "removePhoto": "Hapus Foto",
     "needSelectStatus": "Silakan pilih status pengiriman",
+    "needWatermarkedPhoto": "Harap unggah foto penyerahan dengan watermark sebelum mengirim.",
     "invalidId": "ID DU tidak valid",
     "submit": "Kirim",
     "submitting": "Mengirim…",

--- a/public/locales/zh/index.json
+++ b/public/locales/zh/index.json
@@ -19,6 +19,7 @@
     "photoTip": "支持拍照或从相册选择",
     "removePhoto": "移除照片",
     "needSelectStatus": "请先选择运输状态",
+    "needWatermarkedPhoto": "请上传带有水印的交付照片再提交。",
     "invalidId": "无效的DU ID",
     "submit": "提交",
     "submitting": "提交中…",

--- a/render.yaml
+++ b/render.yaml
@@ -13,3 +13,7 @@ services:
       };
       EOCONFIG
     staticPublishPath: dist
+    routes:
+      - type: rewrite
+        source: /.*/
+        destination: /index.html

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,7 +19,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 });
 

--- a/src/views/ScanView.vue
+++ b/src/views/ScanView.vue
@@ -474,6 +474,16 @@ const submitUpdate = async () => {
     return;
   }
 
+  if (!state.photoFile && !state.photoPreview) {
+    Toastify({
+      text: t('needWatermarkedPhoto'),
+      duration: 3000,
+      gravity: 'bottom',
+      position: 'center',
+    }).showToast();
+    return;
+  }
+
   state.submitting = true;
   state.uploadPct = 0;
   state.submitMsg = '';


### PR DESCRIPTION
## Summary
- require a watermarked photo before submitting scanner updates so the Vue app matches main's validation
- add the corresponding `needWatermarkedPhoto` localization string for English, Indonesian, and Chinese
- add a SPA fallback rewrite and router base so direct navigation to nested routes no longer returns 404s

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd5daefc048320ae6882305ae37244