### PR TITLE
feat: persist auth role and add modal shortcuts

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -58,6 +58,73 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
   let cachedItems = [];
 
   const ROLE_MAP = new Map((ROLE_LIST || []).map((role) => [role.key, role]));
+  const AUTH_STORAGE_KEY = 'jakarta-admin-auth-state';
+
+  function getLocalStorageSafe() {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        return window.localStorage;
+      }
+    } catch (err) {
+      console.error(err);
+    }
+    return null;
+  }
+
+  function sanitizeUserInfo(user) {
+    if (!user || typeof user !== 'object') return null;
+    const info = {};
+    if (user.id != null) info.id = user.id;
+    if (user.name != null) info.name = user.name;
+    return Object.keys(info).length ? info : null;
+  }
+
+  function persistAuthState(roleKey, userInfo) {
+    const storage = getLocalStorageSafe();
+    if (!storage) return;
+    try {
+      if (!roleKey) {
+        storage.removeItem(AUTH_STORAGE_KEY);
+        return;
+      }
+      const payload = {
+        roleKey,
+        userInfo: sanitizeUserInfo(userInfo),
+      };
+      storage.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function loadStoredAuthState() {
+    const storage = getLocalStorageSafe();
+    if (!storage) return null;
+    try {
+      const raw = storage.getItem(AUTH_STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') return null;
+      const { roleKey } = parsed;
+      if (!roleKey || !ROLE_MAP.has(roleKey)) {
+        storage.removeItem(AUTH_STORAGE_KEY);
+        return null;
+      }
+      return {
+        roleKey,
+        userInfo: sanitizeUserInfo(parsed.userInfo),
+      };
+    } catch (err) {
+      console.error(err);
+      try {
+        const storageRef = getLocalStorageSafe();
+        storageRef?.removeItem(AUTH_STORAGE_KEY);
+      } catch (removeErr) {
+        console.error(removeErr);
+      }
+    }
+    return null;
+  }
 
   const DU_RE_FULL = /^DID\d{13}$/;
   const DU_RE_HEAD = /^DID\d{0,13}$/;
@@ -369,7 +436,7 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
 
   function setRole(nextRoleKey, userInfo = null) {
     currentRoleKey = nextRoleKey || null;
-    currentUserInfo = userInfo || null;
+    currentUserInfo = sanitizeUserInfo(userInfo);
     updateAuthButtonLabel();
     updateRoleBadge();
     refreshDnEntryVisibility();
@@ -377,6 +444,7 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     refreshStatusOptionsForRole(currentVal);
     updateModalFieldVisibility();
     rerenderTableActions();
+    persistAuthState(currentRoleKey, currentUserInfo);
   }
 
   function findRoleByPassword(password) {
@@ -1081,6 +1149,9 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
       if (e.key === 'Enter') {
         e.preventDefault();
         handleAuthSubmit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAuthModal();
       }
     },
     { signal }
@@ -1101,6 +1172,31 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     'click',
     (e) => {
       if (e.target === dnModal) closeDnModal();
+    },
+    { signal }
+  );
+
+  const isModalVisible = (modal) => modal && modal.style.display === 'flex';
+
+  document.addEventListener(
+    'keydown',
+    (e) => {
+      if (e.key === 'Escape') {
+        if (isModalVisible(dnModal)) {
+          e.preventDefault();
+          closeDnModal();
+          return;
+        }
+        if (isModalVisible(authModal)) {
+          e.preventDefault();
+          closeAuthModal();
+          return;
+        }
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && isModalVisible(dnModal)) {
+        e.preventDefault();
+        handleDnConfirm();
+      }
     },
     { signal }
   );
@@ -1215,12 +1311,28 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     { signal }
   );
 
+  function restoreAuthFromStorage() {
+    const stored = loadStoredAuthState();
+    if (stored && stored.roleKey) {
+      setRole(stored.roleKey, stored.userInfo);
+    } else {
+      updateAuthButtonLabel();
+      updateRoleBadge();
+      refreshDnEntryVisibility();
+      const currentVal = mStatus?.value || '';
+      refreshStatusOptionsForRole(currentVal);
+      updateModalFieldVisibility();
+      rerenderTableActions();
+    }
+  }
+
   function init() {
     if (!duInput?.value.trim()) renderTokens(['DID']);
     if (hint) hint.textContent = '输入条件后点击查询。';
     fetchList();
   }
 
+  restoreAuthFromStorage();
   init();
   applyAllTranslations();
 


### PR DESCRIPTION
## Summary
- persist authenticated role and user info in local storage and restore it on page load to drive the role badge and permissions
- add Escape handling for both auth and DN modals and support Ctrl+Enter confirmation for DN entry
- ensure UI updates stay in sync when no stored role is found

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8095ae148320b8d943681d4ec891