### PR TITLE
Update dn admin list search endpoint

### DIFF
--- a/src/views/dn-admin/setupDnAdminPage.js
+++ b/src/views/dn-admin/setupDnAdminPage.js
@@ -1019,7 +1019,7 @@ export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
     params.set('status', status);
     params.set('page', '1');
     params.set('page_size', '1');
-    const url = `${API_BASE}/api/dn/search?${params.toString()}`;
+    const url = `${API_BASE}/api/dn/list/search?${params.toString()}`;
     const resp = await fetch(url, { signal });
     const text = await resp.text();
     let data = null;
@@ -1306,7 +1306,9 @@ export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
       pager.style.display = 'none';
 
       const params = buildParamsAuto();
-      const url = `${API_BASE}${q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/search?'}${params}`;
+      const url = `${API_BASE}${
+        q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/list/search?'
+      }${params}`;
       const resp = await fetch(url);
       const text = await resp.text();
       let data = null;
@@ -1636,7 +1638,9 @@ export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
       const p1 = new URLSearchParams(q.lastParams);
       p1.set('page', '1');
       p1.set('page_size', String(per));
-      const firstUrl = `${API_BASE}${q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/search?'}${p1.toString()}`;
+      const firstUrl = `${API_BASE}${
+        q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/list/search?'
+      }${p1.toString()}`;
 
       const fResp = await fetch(firstUrl);
       const fRaw = await fResp.text();
@@ -1657,7 +1661,9 @@ export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
         const params = new URLSearchParams(q.lastParams);
         params.set('page', String(p));
         params.set('page_size', String(per));
-        const url = `${API_BASE}${q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/search?'}${params.toString()}`;
+        const url = `${API_BASE}${
+          q.mode === 'batch' ? '/api/dn/batch?' : '/api/dn/list/search?'
+        }${params.toString()}`;
         const r = await fetch(url);
         const raw = await r.text();
         let d = null;


### PR DESCRIPTION
## Summary
- update DN admin fetchList to call the new `/api/dn/list/search` endpoint when not in batch mode
- update status card count retrieval and export logic to use `/api/dn/list/search`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d13ad938f0832096c45c88b7bff5c9