### PR TITLE
Fix DN validation and guidance for dn-admin

### DIFF
--- a/public/locales/en/dn-admin.json
+++ b/public/locales/en/dn-admin.json
@@ -1,8 +1,8 @@
 {
     "title": "DN Submission Records Management",
     "dn.label": "DN Number (supports multiple lines/commas/spaces; multiple means batch query)",
-    "dn.placeholder": "Example:\nDN123...\nDN456...",
-    "dn.tip": "Hint: DN numbers accept letters, digits, and hyphen.",
+    "dn.placeholder": "Example:\nABC123456789012\nABCD1234567890123",
+    "dn.tip": "Hint: DN numbers must be 14-18 characters with 3-5 starting letters followed by digits.",
     "status.label": "Status",
     "status.all": "(All)",
     "status.inTransit": "Start Transport",

--- a/public/locales/id/dn-admin.json
+++ b/public/locales/id/dn-admin.json
@@ -1,8 +1,8 @@
 {
     "title": "Manajemen Catatan Pengajuan DN",
     "dn.label": "Nomor DN (mendukung baris/komma/spasi; lebih dari satu = pencarian batch)",
-    "dn.placeholder": "Contoh:\nDN123...\nDN456...",
-    "dn.tip": "Petunjuk: Nomor DN dapat berisi huruf, angka, dan tanda hubung.",
+    "dn.placeholder": "Contoh:\nABC123456789012\nABCD1234567890123",
+    "dn.tip": "Petunjuk: Nomor DN harus 14-18 karakter dengan 3-5 huruf di awal lalu diikuti angka.",
     "status.label": "Status",
     "status.all": "(Semua)",
     "status.inTransit": "Mulai Pengiriman",

--- a/public/locales/zh/dn-admin.json
+++ b/public/locales/zh/dn-admin.json
@@ -1,8 +1,8 @@
 {
     "title": "DN 提交记录管理",
     "dn.label": "DN 号（支持多行/逗号/空格分隔；多于1个则批量查询）",
-    "dn.placeholder": "示例：\nDN123...\nDN456...",
-    "dn.tip": "提示：DN 号支持字母、数字与短横线。",
+    "dn.placeholder": "示例：\nABC123456789012\nABCD1234567890123",
+    "dn.tip": "提示：DN 号总长度为14-18位，前3-5位为字母，其余为数字。",
     "status.label": "状态",
     "status.all": "（全部）",
     "status.inTransit": "开始运输",

--- a/src/views/DnAdminView.vue
+++ b/src/views/DnAdminView.vue
@@ -54,11 +54,11 @@
               <textarea
                 id="f-dn"
                 data-i18n-placeholder="dn.placeholder"
-                placeholder="示例：&#10;DN123...&#10;DN456..."
+                placeholder="示例：&#10;ABC123456789012&#10;ABCD1234567890123"
               ></textarea>
             </div>
             <div class="muted" style="margin-top: 6px" data-i18n="dn.tip">
-              提示：DN 号支持字母数字与短横线。
+              提示：DN 号总长度为 14-18 位，前 3-5 位为字母，其余为数字。
             </div>
           </div>
 

--- a/src/views/dn-admin/setupDnAdminPage.js
+++ b/src/views/dn-admin/setupDnAdminPage.js
@@ -12,7 +12,7 @@ const API_BASE =
   window.location.origin;
 
 const DN_SEP_RE = /[\s,，；;、\u3001]+/gu;
-const DN_VALID_RE = /^[A-Z0-9-]{1,64}$/;
+const DN_VALID_RE = /^(?=.{14,18}$)[A-Z]{3,5}[0-9]+$/;
 
 export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
   if (!rootEl) return () => {};


### PR DESCRIPTION
## Summary
- tighten DN validation on the dn-admin page to enforce 14-18 characters with 3-5 leading letters followed by digits
- update on-page guidance and locale strings to describe the new DN format and examples

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15c731b488320a82d6da47891ea0d