### PR TITLE
Update DN export handling and add records export

### DIFF
--- a/public/locales/en/dn-admin.json
+++ b/public/locales/en/dn-admin.json
@@ -58,6 +58,7 @@
     "actions.query": "Search",
     "actions.reset": "Reset",
     "actions.exportAll": "Export All",
+    "actions.exportRecords": "Export DN Update Records",
     "actions.trustBackend": "Trust Backend",
     "actions.syncGoogleSheet": "Update Google Sheet Data",
     "actions.syncGoogleSheetSuccess": "Google Sheet sync triggered",

--- a/public/locales/id/dn-admin.json
+++ b/public/locales/id/dn-admin.json
@@ -58,6 +58,7 @@
     "actions.query": "Cari",
     "actions.reset": "Atur Ulang",
     "actions.exportAll": "Ekspor Semua",
+    "actions.exportRecords": "Ekspor Catatan Pembaruan DN",
     "actions.trustBackend": "Percaya Backend",
     "actions.syncGoogleSheet": "Perbarui data Google Sheet",
     "actions.syncGoogleSheetSuccess": "Sinkronisasi Google Sheet telah dijalankan",

--- a/public/locales/zh/dn-admin.json
+++ b/public/locales/zh/dn-admin.json
@@ -58,6 +58,7 @@
     "actions.query": "查询",
     "actions.reset": "重置",
     "actions.exportAll": "导出全部",
+    "actions.exportRecords": "导出DN更新记录",
     "actions.trustBackend": "信任后台",
     "actions.syncGoogleSheet": "更新Google Sheet数据",
     "actions.syncGoogleSheetSuccess": "已触发 Google Sheet 数据更新",

--- a/src/views/DnAdminView.vue
+++ b/src/views/DnAdminView.vue
@@ -197,6 +197,13 @@
                   <button class="btn ghost" id="btn-export-all" data-i18n="actions.exportAll">
                     导出全部
                   </button>
+                  <button
+                    class="btn ghost"
+                    id="btn-export-records"
+                    data-i18n="actions.exportRecords"
+                  >
+                    导出DN更新记录
+                  </button>
                   <button class="btn ghost" id="btn-trust-backend-link" data-i18n="actions.trustBackend">
                     信任后台
                   </button>


### PR DESCRIPTION
## Summary
- call the non-paginated `/api/dn/list` (and batch equivalent) when exporting DN search results
- add a new "Export DN Update Records" action that pulls `/api/dn/records` into a CSV download
- translate the new action label in all supported locales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1804818f08320b665781a09d89a93