### PR TITLE
Adjust status cards layout and delivery filter integration

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -297,7 +297,7 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     statusCardWrapper.style.display = '';
     statusCardWrapper.setAttribute('aria-hidden', 'false');
     statusCardContainer.innerHTML = '';
-    const columns = Math.max(1, Math.min(defs.length, 4));
+    const columns = Math.max(1, Math.min(defs.length, 9));
     statusCardContainer.style.setProperty('--status-card-columns', String(columns));
 
     defs.forEach((def) => {


### PR DESCRIPTION
## Summary
- allow up to nine status highlight cards per row across admin screens
- connect delivery status highlight cards to the status_delivery filter and keep their active state in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d257091eb88320bd7b5383340ddcd8