### PR TITLE
Allow up to 13 status cards per row

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -64,6 +64,7 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
   const statusCardRefs = new Map();
   let statusCardAbortController = null;
   let statusCardRequestId = 0;
+  const STATUS_CARD_MAX_COLUMNS = 13;
 
   const ROLE_MAP = new Map((ROLE_LIST || []).map((role) => [role.key, role]));
   const AUTH_STORAGE_KEY = 'jakarta-admin-auth-state';
@@ -297,7 +298,10 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     statusCardWrapper.style.display = '';
     statusCardWrapper.setAttribute('aria-hidden', 'false');
     statusCardContainer.innerHTML = '';
-    const columns = Math.max(1, Math.min(defs.length, 9));
+    const columns = Math.max(
+      1,
+      Math.min(defs.length, STATUS_CARD_MAX_COLUMNS)
+    );
     statusCardContainer.style.setProperty('--status-card-columns', String(columns));
 
     defs.forEach((def) => {

--- a/src/views/dn-admin/setupDnAdminPage.js
+++ b/src/views/dn-admin/setupDnAdminPage.js
@@ -99,6 +99,7 @@ export function setupDnAdminPage(rootEl, { i18n, applyTranslations } = {}) {
   let statusCardAbortController = null;
   let statusCardRequestId = 0;
   let viewer = null;
+  const STATUS_CARD_MAX_COLUMNS = 13;
 
   const ROLE_MAP = new Map((ROLE_LIST || []).map((role) => [role.key, role]));
   const AUTH_STORAGE_KEY = 'jakarta-dn-admin-auth-state';
@@ -1599,7 +1600,10 @@ ${cellsHtml}
     statusCardWrapper.style.display = '';
     statusCardWrapper.setAttribute('aria-hidden', 'false');
     statusCardContainer.innerHTML = '';
-    const columns = Math.max(1, Math.min(defs.length, 10));
+    const columns = Math.max(
+      1,
+      Math.min(defs.length, STATUS_CARD_MAX_COLUMNS)
+    );
     statusCardContainer.style.setProperty('--status-card-columns', String(columns));
 
     defs.forEach((def) => {


### PR DESCRIPTION
## Summary
- add a shared max column constant for status card grids in both admin dashboards
- raise the cap so layouts can render up to 13 cards on one row when width permits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d298596c5083209d195e1d14a5c48f