### PR TITLE
Adjust DN admin status defaults and add show all filter control

### DIFF
--- a/public/locales/en/dn-admin.json
+++ b/public/locales/en/dn-admin.json
@@ -66,6 +66,7 @@
     "actions.label": "Actions",
     "actions.query": "Search",
     "actions.reset": "Reset",
+    "actions.showAll": "Show all DN",
     "actions.exportAll": "Export All",
     "actions.exportRecords": "Export DN Update Records",
     "actions.trustBackend": "Trust Backend",

--- a/public/locales/id/dn-admin.json
+++ b/public/locales/id/dn-admin.json
@@ -66,6 +66,7 @@
     "actions.label": "Tindakan",
     "actions.query": "Cari",
     "actions.reset": "Atur Ulang",
+    "actions.showAll": "Tampilkan semua DN",
     "actions.exportAll": "Ekspor Semua",
     "actions.exportRecords": "Ekspor Catatan Pembaruan DN",
     "actions.trustBackend": "Percaya Backend",

--- a/public/locales/zh/dn-admin.json
+++ b/public/locales/zh/dn-admin.json
@@ -66,6 +66,7 @@
     "actions.label": "操作",
     "actions.query": "查询",
     "actions.reset": "重置",
+    "actions.showAll": "显示全部 DN",
     "actions.exportAll": "导出全部",
     "actions.exportRecords": "导出DN更新记录",
     "actions.trustBackend": "信任后台",

--- a/src/views/DnAdminView.vue
+++ b/src/views/DnAdminView.vue
@@ -240,6 +240,9 @@
                 <div style="display: flex; gap: 8px; flex-wrap: wrap">
                   <button class="btn" id="btn-search" data-i18n="actions.query">查询</button>
                   <button class="btn ghost" id="btn-reset" data-i18n="actions.reset">重置</button>
+                  <button class="btn ghost" id="btn-show-all" data-i18n="actions.showAll">
+                    显示全部 DN
+                  </button>
                   <button class="btn ghost" id="btn-export-all" data-i18n="actions.exportAll">
                     导出全部
                   </button>

--- a/src/views/dn-admin/setupDnAdminPage.js
+++ b/src/views/dn-admin/setupDnAdminPage.js
@@ -202,8 +202,9 @@ export function setupDnAdminPage(
           'TRANSPORTING FROM XD/PM',
           'ARRIVED AT SITE',
         ];
-  const DEFAULT_STATUS_VALUE = statusSelect?.options?.[0]?.value || '';
-  if (statusSelect && DEFAULT_STATUS_VALUE) {
+  const STATUS_ANY_VALUE = '';
+  const DEFAULT_STATUS_VALUE = STATUS_ANY_VALUE;
+  if (statusSelect) {
     statusSelect.value = DEFAULT_STATUS_VALUE;
   }
 
@@ -3155,6 +3156,38 @@ ${cellsHtml}
     { signal }
   );
 
+  function resetAllFilters({ statusValue = STATUS_ANY_VALUE } = {}) {
+    const defaultValues = {
+      'f-status': statusValue,
+      'f-remark': '',
+      'f-has': '',
+      'f-has-coordinate': '',
+      'f-from': '',
+      'f-to': '',
+      'f-ps2': '20',
+      'f-du': '',
+      'f-lsp': '',
+      'f-region': '',
+      'f-plan-mos-date': '',
+      'f-subcon': '',
+      'f-status-wh': '',
+      'f-status-delivery': '',
+    };
+    Object.entries(defaultValues).forEach(([id, value]) => {
+      const filterKey = FILTER_KEY_BY_ID.get(id);
+      if (filterKey) {
+        const node = el(id);
+        setFilterValue(filterKey, node, value);
+        return;
+      }
+      const node = el(id);
+      if (!node) return;
+      setFormControlValue(node, value);
+    });
+    if (dnInput) dnInput.value = '';
+    normalizeDnInput({ enforceFormat: false });
+  }
+
   el('btn-search')?.addEventListener(
     'click',
     () => {
@@ -3167,35 +3200,17 @@ ${cellsHtml}
   el('btn-reset')?.addEventListener(
     'click',
     () => {
-      const defaultValues = {
-        'f-status': DEFAULT_STATUS_VALUE,
-        'f-remark': '',
-        'f-has': '',
-        'f-has-coordinate': '',
-        'f-from': '',
-        'f-to': '',
-        'f-ps2': '20',
-        'f-du': '',
-        'f-lsp': '',
-        'f-region': '',
-        'f-plan-mos-date': '',
-        'f-subcon': '',
-        'f-status-wh': '',
-        'f-status-delivery': '',
-      };
-      Object.entries(defaultValues).forEach(([id, value]) => {
-        const filterKey = FILTER_KEY_BY_ID.get(id);
-        if (filterKey) {
-          const node = el(id);
-          setFilterValue(filterKey, node, value);
-          return;
-        }
-        const node = el(id);
-        if (!node) return;
-        setFormControlValue(node, value);
-      });
-      if (dnInput) dnInput.value = '';
-      normalizeDnInput({ enforceFormat: false });
+      resetAllFilters({ statusValue: DEFAULT_STATUS_VALUE });
+      q.page = 1;
+      fetchList();
+    },
+    { signal }
+  );
+
+  el('btn-show-all')?.addEventListener(
+    'click',
+    () => {
+      resetAllFilters({ statusValue: STATUS_ANY_VALUE });
       q.page = 1;
       fetchList();
     },


### PR DESCRIPTION
## Summary
- keep the DN Admin status filter defaulting to the "Any" option when resetting filters
- add a "Show all DN" action that clears filters, sets the status filter to Any, and reruns the search
- localize the new action label in all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b12f3c0c832081f42390afada315