### PR TITLE
Hide status box after successful submit

### DIFF
--- a/src/views/ScanView.vue
+++ b/src/views/ScanView.vue
@@ -77,7 +77,7 @@
       </div>
 
       <template v-if="state.isValid">
-        <div class="status-box">
+        <div class="status-box" v-show="!state.submitOk">
           <div class="status-row" :class="{ shake: state.needsStatusShake }">
             <label for="dnStatus">{{ t('updateStatus') }}：</label>
             <select


### PR DESCRIPTION
## Summary
- hide the status box form after a successful submission by toggling it with submit state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d554b35e088320a47602ecbb6b31ce