### PR TITLE
Ensure admin save uses stored user info

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -608,6 +608,22 @@ export function setupAdminPage(
     return null;
   }
 
+  function getEffectiveUserInfo() {
+    if (currentUserInfo?.name) return currentUserInfo;
+    const stored = loadStoredAuthState();
+    if (stored?.userInfo) {
+      const sanitized = sanitizeUserInfo({
+        ...(currentUserInfo || {}),
+        ...stored.userInfo,
+      });
+      if (sanitized) {
+        currentUserInfo = sanitized;
+        return sanitized;
+      }
+    }
+    return currentUserInfo;
+  }
+
   function normalizeStatusValue(raw) {
     const text = (raw || '').trim();
     if (!text) return '';
@@ -1648,7 +1664,8 @@ ${cellsHtml}
       form.set('dnNumber', dnNumber);
     }
 
-    const updatedBy = (currentUserInfo?.name || '').trim();
+    const resolvedUser = getEffectiveUserInfo();
+    const updatedBy = (resolvedUser?.name || '').trim();
     form.set('updated_by', updatedBy);
 
     const originalStatusRaw = currentItem?.status || '';


### PR DESCRIPTION
## Summary
- add a helper to lazily hydrate the cached admin user info from local storage
- ensure the save form resolves the current user before setting the updated_by field

## Testing
- npm run build (fails: Rollup could not resolve import "ant-design-vue")

------
https://chatgpt.com/codex/tasks/task_e_68d57410f8388320ae328f15397fece8