### PR TITLE
feat: add route calculator view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "v-viewer": "3.0.11",
         "viewerjs": "1.11.6",
         "vue": "3.4.38",
-        "vue-router": "4.3.2"
+        "vue-router": "4.3.2",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "5.0.4",
@@ -953,6 +954,15 @@
       "integrity": "sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==",
       "license": "MIT"
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ant-design-vue": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/ant-design-vue/-/ant-design-vue-4.2.6.tgz",
@@ -1005,6 +1015,28 @@
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
       "license": "MIT"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
@@ -1020,6 +1052,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/csstype": {
@@ -1102,6 +1146,15 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1295,6 +1348,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
@@ -1449,6 +1514,45 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "ant-design-vue": "^4.2.6",
     "dayjs": "^1.11.18",
     "toastify-js": "1.12.0",
-    "viewerjs": "1.11.6",
     "v-viewer": "3.0.11",
+    "viewerjs": "1.11.6",
     "vue": "3.4.38",
-    "vue-router": "4.3.2"
+    "vue-router": "4.3.2",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "5.0.4",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,6 +16,11 @@ const routes = [
     name: 'dashboard',
     component: () => import('../views/DashboardView.vue'),
   },
+  {
+    path: '/routes',
+    name: 'routes',
+    component: () => import('../views/RouteCalculatorView.vue'),
+  },
 ];
 
 const router = createRouter({

--- a/src/views/RouteCalculatorView.vue
+++ b/src/views/RouteCalculatorView.vue
@@ -1,0 +1,468 @@
+<template>
+  <div class="route-calculator-view">
+    <section class="card upload-card">
+      <h1>Route Calculator</h1>
+      <p class="description">
+        Upload an Excel file with warehouse and destination coordinates to calculate driving distance
+        and duration.
+      </p>
+      <div class="actions">
+        <label class="upload-button">
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".xlsx,.xls"
+            @change="onFileChange"
+            :disabled="isProcessing"
+          />
+          <span>{{ isProcessing ? 'Processing…' : 'Select Excel File' }}</span>
+        </label>
+        <button v-if="rows.length" class="clear-button" @click="reset" :disabled="isProcessing">
+          Clear Data
+        </button>
+      </div>
+      <p v-if="uploadError" class="error">{{ uploadError }}</p>
+      <p v-if="rows.length" class="hint">
+        Showing {{ rows.length }} row{{ rows.length === 1 ? '' : 's' }} from the first worksheet.
+      </p>
+    </section>
+
+    <section v-if="rows.length" class="card table-card">
+      <header class="table-header">
+        <h2>Calculated Routes</h2>
+        <p class="status" v-if="progressMessage">{{ progressMessage }}</p>
+      </header>
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>Warehouse Name</th>
+              <th>Warehouse Coordinates (lon, lat)</th>
+              <th>Destination Name</th>
+              <th>Destination Coordinates (lon, lat)</th>
+              <th>Distance (km)</th>
+              <th>Duration (h)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in rows" :key="row.id">
+              <td>{{ row.warehouseName }}</td>
+              <td>{{ row.warehouseCoordsRaw }}</td>
+              <td>{{ row.destinationName }}</td>
+              <td>{{ row.destinationCoordsRaw }}</td>
+              <td>
+                <span v-if="row.distanceKm !== null">{{ row.distanceKm }}</span>
+                <span v-else-if="row.status === 'processing'">Loading…</span>
+                <span v-else-if="row.status === 'pending'">Waiting…</span>
+                <span v-else>—</span>
+                <small v-if="row.error" class="cell-error">{{ row.error }}</small>
+              </td>
+              <td>
+                <span v-if="row.durationHours !== null">{{ row.durationHours }}</span>
+                <span v-else-if="row.status === 'processing'">Loading…</span>
+                <span v-else-if="row.status === 'pending'">Waiting…</span>
+                <span v-else>—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, ref } from 'vue';
+import * as XLSX from 'xlsx';
+import { useBodyTheme } from '../composables/useBodyTheme';
+
+const MAPBOX_ACCESS_TOKEN =
+  'pk.eyJ1IjoicnFiMjR2cDIiLCJhIjoiY201dGlodTU3MHcyYzJqcTBoN3BsdDA4NiJ9.YSHAPavjlOhdbKx8Z7gPWA';
+
+useBodyTheme(null);
+
+const fileInput = ref(null);
+const rows = ref([]);
+const uploadError = ref('');
+const isProcessing = ref(false);
+const currentIndex = ref(-1);
+
+const completedCount = computed(() =>
+  rows.value.filter((row) => row.status === 'done').length
+);
+const processedCount = computed(() =>
+  rows.value.filter((row) => row.status !== 'pending' && row.status !== 'processing').length
+);
+const progressMessage = computed(() => {
+  if (!rows.value.length) return '';
+  if (isProcessing.value) {
+    const processed = processedCount.value;
+    const current = currentIndex.value >= 0 ? currentIndex.value + 1 : processed;
+    return `Processing ${Math.min(current, rows.value.length)} of ${rows.value.length}`;
+  }
+  if (!processedCount.value) {
+    return '';
+  }
+  return `Processed ${processedCount.value} of ${rows.value.length} rows (${completedCount.value} succeeded)`;
+});
+
+const onFileChange = async (event) => {
+  const [file] = event.target.files || [];
+  if (!file) return;
+
+  uploadError.value = '';
+  rows.value = [];
+
+  try {
+    const parsedRows = await readExcelFile(file);
+    if (!parsedRows.length) {
+      uploadError.value = 'No data found in the first worksheet.';
+      return;
+    }
+    rows.value = parsedRows;
+    await nextTick();
+    await processRowsSequentially();
+  } catch (error) {
+    uploadError.value = error?.message || 'Failed to read the uploaded file.';
+  } finally {
+    if (fileInput.value) {
+      fileInput.value.value = '';
+    }
+  }
+};
+
+const reset = () => {
+  rows.value = [];
+  uploadError.value = '';
+  isProcessing.value = false;
+  currentIndex.value = -1;
+  if (fileInput.value) {
+    fileInput.value.value = '';
+  }
+};
+
+const readExcelFile = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = new Uint8Array(e.target.result);
+        const workbook = XLSX.read(data, { type: 'array' });
+        if (!workbook.SheetNames.length) {
+          resolve([]);
+          return;
+        }
+        const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+        const rawRows = XLSX.utils.sheet_to_json(worksheet, { header: 1, raw: true });
+        const parsed = rawRows
+          .map((cells, index) => parseRow(cells, index))
+          .filter((row) => row !== null);
+        resolve(parsed);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    reader.onerror = () => reject(new Error('Unable to read the selected file.'));
+    reader.readAsArrayBuffer(file);
+  });
+
+const parseRow = (cells = [], index) => {
+  const hasValue = Array.isArray(cells)
+    ? cells.some((cell) => !(cell === undefined || cell === null || String(cell).trim() === ''))
+    : false;
+  if (!hasValue) {
+    return null;
+  }
+
+  const warehouseName = formatCellValue(cells[0]);
+  const warehouseCoordsRaw = formatCellValue(cells[1]);
+  const destinationName = formatCellValue(cells[2]);
+  const destinationCoordsRaw = formatCellValue(cells[3]);
+
+  return {
+    id: index,
+    warehouseName,
+    warehouseCoordsRaw,
+    destinationName,
+    destinationCoordsRaw,
+    distanceKm: null,
+    durationHours: null,
+    status: 'pending',
+    error: '',
+    origin: parseCoordinatePair(warehouseCoordsRaw),
+    destination: parseCoordinatePair(destinationCoordsRaw),
+  };
+};
+
+const formatCellValue = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  return String(value).trim();
+};
+
+const parseCoordinatePair = (value) => {
+  if (!value) return null;
+  const cleaned = value.replace(/\s+/g, '');
+  const parts = cleaned.split(',');
+  if (parts.length !== 2) return null;
+  const lon = Number.parseFloat(parts[0]);
+  const lat = Number.parseFloat(parts[1]);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null;
+  return { lon, lat };
+};
+
+const processRowsSequentially = async () => {
+  if (!rows.value.length) return;
+  isProcessing.value = true;
+  currentIndex.value = -1;
+
+  for (let i = 0; i < rows.value.length; i += 1) {
+    currentIndex.value = i;
+    const row = rows.value[i];
+
+    if (!row.origin || !row.destination) {
+      row.status = 'error';
+      row.error = 'Invalid coordinate pair';
+      continue;
+    }
+
+    row.status = 'processing';
+    row.error = '';
+
+    try {
+      const result = await fetchRoute(row.origin, row.destination);
+      row.distanceKm = formatDecimal(result.distance / 1000);
+      row.durationHours = formatDecimal(result.duration / 3600);
+      row.status = 'done';
+    } catch (error) {
+      row.status = 'error';
+      row.error = error?.message || 'Failed to fetch route';
+    }
+  }
+
+  currentIndex.value = -1;
+  isProcessing.value = false;
+};
+
+const fetchRoute = async (origin, destination) => {
+  const url = new URL(
+    `https://api.mapbox.com/directions/v5/mapbox/driving/${origin.lon},${origin.lat};${destination.lon},${destination.lat}`
+  );
+  url.search = new URLSearchParams({
+    access_token: MAPBOX_ACCESS_TOKEN,
+    overview: 'false',
+    geometries: 'geojson',
+  }).toString();
+
+  const response = await fetch(url.toString());
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('Unable to parse response from Mapbox');
+  }
+
+  if (!response.ok) {
+    const message = data?.message || `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  const route = Array.isArray(data?.routes) ? data.routes[0] : null;
+  if (!route) {
+    throw new Error('No route data returned');
+  }
+
+  const distance = Number(route.distance);
+  const duration = Number(route.duration);
+  if (!Number.isFinite(distance) || !Number.isFinite(duration)) {
+    throw new Error('Route data is incomplete');
+  }
+
+  return {
+    distance,
+    duration,
+  };
+};
+
+const formatDecimal = (value) => {
+  if (!Number.isFinite(value)) return null;
+  return value.toFixed(2);
+};
+</script>
+
+<style scoped>
+.route-calculator-view {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid #e2e8f0;
+}
+
+.upload-card h1 {
+  margin: 0 0 8px;
+  font-size: 24px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.description {
+  margin: 0 0 16px;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.upload-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.upload-button:hover {
+  background: #1d4ed8;
+}
+
+.upload-button input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.upload-button input[type='file']:disabled {
+  cursor: not-allowed;
+}
+
+.clear-button {
+  appearance: none;
+  border: 1px solid #cbd5f5;
+  background: transparent;
+  color: #2563eb;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.clear-button:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.clear-button:disabled,
+.upload-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  margin-top: 12px;
+  color: #dc2626;
+}
+
+.hint {
+  margin-top: 12px;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.table-card {
+  overflow: hidden;
+}
+
+.table-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.table-header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: #0f172a;
+}
+
+.status {
+  margin: 0;
+  font-size: 14px;
+  color: #475569;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f8fafc;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: top;
+  font-size: 14px;
+}
+
+th {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+tbody tr:nth-child(even) {
+  background: #f8fafc;
+}
+
+.cell-error {
+  display: block;
+  margin-top: 4px;
+  color: #dc2626;
+  font-size: 12px;
+}
+
+@media (max-width: 768px) {
+  .route-calculator-view {
+    padding: 24px 12px;
+  }
+
+  th,
+  td {
+    padding: 10px 12px;
+    font-size: 13px;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add a RouteCalculatorView at /routes that ingests Excel files, displays rows, and sequentially fills distance and duration using the Mapbox Directions API
- parse spreadsheets with the xlsx library and surface upload feedback with progress messaging and error handling
- register the new view in the router and add the xlsx dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69e218c488320bf5292506ab75bdb