### PR TITLE
Trigger admin search when pressing enter on per-page input

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -1507,11 +1507,20 @@ export function setupAdminPage(rootEl, { i18n, applyTranslations }) {
     );
   }
 
-  el('btn-search')?.addEventListener(
-    'click',
-    () => {
-      q.page = 1;
-      fetchList();
+  const triggerSearch = () => {
+    q.page = 1;
+    fetchList();
+  };
+
+  el('btn-search')?.addEventListener('click', triggerSearch, { signal });
+
+  el('f-ps2')?.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        triggerSearch();
+      }
     },
     { signal }
   );


### PR DESCRIPTION
## Summary
- refactor admin search handler into a reusable function
- trigger a fresh search when pressing Enter inside the per-page input

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7674757808320984b19e219c4e953