### PR TITLE
Increase admin page size cap to 1000

### DIFF
--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -291,7 +291,7 @@
               id="f-ps2"
               type="number"
               min="1"
-              max="100"
+              max="1000"
               value="20"
               class="w120"
               data-i18n-placeholder="perPage.placeholder"

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -482,7 +482,7 @@ export function setupAdminPage(
       setFormControlValue(pageSizeInput, String(fallback));
       return fallback;
     }
-    const normalized = Math.min(100, Math.max(1, Math.floor(raw)));
+    const normalized = Math.min(1000, Math.max(1, Math.floor(raw)));
     if (String(normalized) !== String(pageSizeInput.value)) {
       setFormControlValue(pageSizeInput, String(normalized));
     }


### PR DESCRIPTION
## Summary
- allow admins to enter up to 1000 items per page in the pager input
- raise the client-side normalization limit so larger page sizes are preserved

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fa6269808320b576a02c554db0fe