### PR TITLE
Add tooltip for mismatched delivery statuses in admin view

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -112,6 +112,7 @@
     "table.updatedAt": "Last Updated",
     "table.coords": "Coordinates",
     "table.actions": "Actions",
+    "table.statusMismatchTooltip": "Delivery status (status_delivery) does not match the driver-uploaded cargo status (status). Please review and update.",
     "table.expandHint": "Click to view all fields",
     "table.photoIconLabel": "View photo",
     "table.mapIconLabel": "Open in Google Maps",

--- a/public/locales/id/admin.json
+++ b/public/locales/id/admin.json
@@ -112,6 +112,7 @@
     "table.updatedAt": "Terakhir Diperbarui",
     "table.coords": "Koordinat",
     "table.actions": "Tindakan",
+    "table.statusMismatchTooltip": "Status pengiriman (status_delivery) tidak selaras dengan status muatan yang diunggah pengemudi (status). Harap periksa dan perbarui.",
     "table.expandHint": "Klik untuk melihat semua kolom",
     "table.photoIconLabel": "Lihat foto",
     "table.mapIconLabel": "Buka di Google Maps",

--- a/public/locales/zh/admin.json
+++ b/public/locales/zh/admin.json
@@ -112,6 +112,7 @@
     "table.updatedAt": "更新时间",
     "table.coords": "经纬度",
     "table.actions": "操作",
+    "table.statusMismatchTooltip": "配送状态(status_delivery)与司机上传的货物状态(status)不一致，请检查并更新。",
     "table.expandHint": "点击查看全部字段",
     "table.photoIconLabel": "查看照片",
     "table.mapIconLabel": "在 Google 地图中打开",

--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -221,6 +221,23 @@ body.admin-theme {
     color: #7f96c2;
     margin-top: 4px
     }
+.admin-page .status-text {
+    display: inline-block
+    }
+.admin-page .status-mismatch {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px
+    }
+.admin-page .status-mismatch-icon {
+    color: #ff4d4f;
+    font-size: 14px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: help
+    }
 .admin-page tr.summary-row .row-toggle::before {
     content: '▸';
     display: inline-block;


### PR DESCRIPTION
## Summary
- mark status cells with a tooltip when delivery and driver statuses conflict
- style the mismatch indicator and localize its tooltip across supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8003da6cc83209d8a06446b4a5079