### PR TITLE
Use search endpoint for DN export

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -67,7 +67,7 @@
     "actions.query": "Search",
     "actions.reset": "Reset",
     "actions.showAll": "Show all DN",
-    "actions.exportAll": "Export All",
+    "actions.exportAll": "Export DN",
     "actions.exportRecords": "Export DN Update Records",
     "actions.trustBackend": "Trust Backend",
     "actions.syncGoogleSheet": "Update Google Sheet Data",
@@ -152,7 +152,7 @@
     "dn.toast.denied": "Current role cannot add DN entries",
     "dn.toast.empty": "Please input at least one DN number",
     "dn.toast.error": "DN import failed",
-    "actions.exporting": "Exporting all data, please wait…",
+    "actions.exporting": "Exporting data, please wait…",
     "actions.exportNone": "No matching data to export.",
     "actions.exportError": "Export failed",
     "pager.info": "Page {page} / {pages}, total {total} items"

--- a/public/locales/id/admin.json
+++ b/public/locales/id/admin.json
@@ -67,7 +67,7 @@
     "actions.query": "Cari",
     "actions.reset": "Atur Ulang",
     "actions.showAll": "Tampilkan semua DN",
-    "actions.exportAll": "Ekspor Semua",
+    "actions.exportAll": "Ekspor DN",
     "actions.exportRecords": "Ekspor Catatan Pembaruan DN",
     "actions.trustBackend": "Percaya Backend",
     "actions.syncGoogleSheet": "Perbarui data Google Sheet",
@@ -152,7 +152,7 @@
     "dn.toast.denied": "Peran saat ini tidak dapat melakukan entri DN",
     "dn.toast.empty": "Masukkan minimal satu nomor DN",
     "dn.toast.error": "Gagal melakukan entri DN",
-    "actions.exporting": "Sedang mengekspor semua data, mohon tunggu…",
+    "actions.exporting": "Sedang mengekspor data, mohon tunggu…",
     "actions.exportNone": "Tidak ada data yang cocok untuk diekspor.",
     "actions.exportError": "Ekspor gagal",
     "pager.info": "Halaman {page} / {pages}, total {total} item"

--- a/public/locales/zh/admin.json
+++ b/public/locales/zh/admin.json
@@ -67,7 +67,7 @@
     "actions.query": "查询",
     "actions.reset": "重置",
     "actions.showAll": "显示全部 DN",
-    "actions.exportAll": "导出全部",
+    "actions.exportAll": "导出DN",
     "actions.exportRecords": "导出DN更新记录",
     "actions.trustBackend": "信任后台",
     "actions.syncGoogleSheet": "更新Google Sheet数据",
@@ -152,7 +152,7 @@
     "dn.toast.denied": "当前角色无权录入 DN",
     "dn.toast.empty": "请至少输入一个 DN 号",
     "dn.toast.error": "DN 录入失败",
-    "actions.exporting": "正在导出全部数据，请稍候…",
+    "actions.exporting": "正在导出数据，请稍候…",
     "actions.exportNone": "没有匹配的数据可导出。",
     "actions.exportError": "导出失败",
     "pager.info": "第 {page} / {pages} 页，共 {total} 条"

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -222,7 +222,7 @@
                     显示全部 DN
                   </button>
                   <button class="btn ghost" id="btn-export-all" data-i18n="actions.exportAll">
-                    导出全部
+                    导出DN
                   </button>
                   <button
                     class="btn ghost"

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -2261,9 +2261,10 @@ ${cellsHtml}
   async function exportAll() {
     if (!hint) return;
     try {
-      hint.textContent = i18n?.t('actions.exporting') || '正在导出全部数据，请稍候…';
+      hint.textContent = i18n?.t('actions.exporting') || '正在导出数据，请稍候…';
       const params = getExportSearchParams();
-      const basePath = q.mode === 'batch' ? '/api/dn/batch/list' : '/api/dn/list';
+      const basePath =
+        q.mode === 'batch' ? '/api/dn/list/batch' : '/api/dn/list/search';
       const url = buildExportUrl(basePath, params);
 
       const resp = await fetch(url);
@@ -2299,7 +2300,7 @@ ${cellsHtml}
   async function exportUpdateRecords() {
     if (!hint) return;
     try {
-      hint.textContent = i18n?.t('actions.exporting') || '正在导出全部数据，请稍候…';
+      hint.textContent = i18n?.t('actions.exporting') || '正在导出数据，请稍候…';
       const params = getExportSearchParams();
       const url = buildExportUrl('/api/dn/records', params);
 


### PR DESCRIPTION
## Summary
- rename the admin export button to “Export DN” and update translations
- route the export-all action through the search endpoint so it downloads the full filtered result set
- refresh the export status copy to reflect the new behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d804a650ec8320abc0cbc96ff6bbd2