### PR TITLE
Replace show-all DN button with status switch

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -67,6 +67,8 @@
     "actions.query": "Search",
     "actions.reset": "Reset",
     "actions.showAll": "Show all DN",
+    "actions.statusSwitch.checked": "Only DN with status",
+    "actions.statusSwitch.unchecked": "Show all DN",
     "actions.exportAll": "Export DN",
     "actions.exportRecords": "Export DN Update Records",
     "actions.trustBackend": "Trust Backend",

--- a/public/locales/id/admin.json
+++ b/public/locales/id/admin.json
@@ -67,6 +67,8 @@
     "actions.query": "Cari",
     "actions.reset": "Atur Ulang",
     "actions.showAll": "Tampilkan semua DN",
+    "actions.statusSwitch.checked": "Hanya DN dengan status",
+    "actions.statusSwitch.unchecked": "Tampilkan semua DN",
     "actions.exportAll": "Ekspor DN",
     "actions.exportRecords": "Ekspor Catatan Pembaruan DN",
     "actions.trustBackend": "Percaya Backend",

--- a/public/locales/zh/admin.json
+++ b/public/locales/zh/admin.json
@@ -67,6 +67,8 @@
     "actions.query": "查询",
     "actions.reset": "重置",
     "actions.showAll": "显示全部 DN",
+    "actions.statusSwitch.checked": "仅显示有状态 DN",
+    "actions.statusSwitch.unchecked": "显示全部 DN",
     "actions.exportAll": "导出DN",
     "actions.exportRecords": "导出DN更新记录",
     "actions.trustBackend": "信任后台",

--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -475,6 +475,17 @@ body.admin-theme {
     flex: 1 1 100%;
     max-width: 100%
     }
+.admin-page .status-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px
+    }
+.admin-page .status-switch__label {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px
+    }
 .admin-page .row-line {
     display: flex;
     gap: 10px;

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -2454,10 +2454,12 @@ ${cellsHtml}
     { signal }
   );
 
-  el('btn-show-all')?.addEventListener(
-    'click',
-    () => {
-      resetAllFilters({ statusValue: STATUS_ANY_VALUE });
+  rootEl.addEventListener(
+    'admin:status-switch-change',
+    (event) => {
+      const detail = event?.detail || {};
+      const targetValue = detail.showOnlyNonEmpty ? DEFAULT_STATUS_VALUE : STATUS_ANY_VALUE;
+      setFilterValue('status', targetValue);
       q.page = 1;
       fetchList();
     },


### PR DESCRIPTION
## Summary
- replace the "show all DN" button with an Ant Design switch that toggles between any status and non-empty status filters
- keep the switch and status dropdown values in sync via custom events and localized labels, adding styling for the new control

## Testing
- npm run build *(fails: missing dependencies such as ant-design-vue in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d806b6747c832095d1ea2d6abc9573