### PR TITLE
Highlight status mismatches across entire row

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -227,16 +227,32 @@ body.admin-theme {
 .admin-page .status-mismatch {
     display: inline-flex;
     align-items: center;
-    margin-left: 4px
+    margin-left: 6px
     }
 .admin-page .status-mismatch-icon {
     color: #ff4d4f;
-    font-size: 14px;
+    font-size: 12px;
     line-height: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    cursor: help
+    cursor: help;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    font-weight: 700;
+    box-shadow: 0 0 0 1px rgba(255, 77, 79, 0.2);
+    flex-shrink: 0
+    }
+.admin-page tr.summary-row.status-mismatch-row {
+    background: rgba(255, 77, 79, 0.12)
+    }
+.admin-page tr.summary-row.status-mismatch-row.expandable:hover {
+    background: rgba(255, 77, 79, 0.18)
+    }
+.admin-page tr.summary-row.status-mismatch-row.expanded {
+    background: rgba(255, 77, 79, 0.18)
     }
 .admin-page tr.summary-row .row-toggle::before {
     content: '▸';

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -1448,7 +1448,7 @@ ${cellsHtml}
                     role: 'img',
                     'aria-label': message,
                   },
-                  '✖'
+                  '!'
                 ),
             }
           );
@@ -1463,7 +1463,14 @@ ${cellsHtml}
     if (!tbody) return;
     cleanupStatusMismatchTooltips();
     const tooltipMessage = getStatusMismatchTooltipMessage();
+    const processedRows = new Set();
     tbody.querySelectorAll('td[data-raw-status]').forEach((td) => {
+      const summaryRow = td.closest('tr.summary-row');
+      if (summaryRow && !processedRows.has(summaryRow)) {
+        summaryRow.classList.remove('status-mismatch-row');
+        summaryRow.removeAttribute('data-status-mismatch');
+        processedRows.add(summaryRow);
+      }
       const raw = td.getAttribute('data-raw-status') || '';
       const canonical = normalizeStatusValue(raw);
       const value = canonical || raw;
@@ -1481,6 +1488,10 @@ ${cellsHtml}
         indicator.setAttribute('data-status-mismatch', 'true');
         indicator.setAttribute('data-tooltip-message', tooltipMessage);
         td.appendChild(indicator);
+        if (summaryRow) {
+          summaryRow.classList.add('status-mismatch-row');
+          summaryRow.setAttribute('data-status-mismatch', 'true');
+        }
       }
     });
     setupStatusMismatchTooltips();


### PR DESCRIPTION
## Summary
- highlight admin table rows where status and status_delivery mismatch to make issues obvious
- replace the red cross indicator with a white-backed warning icon for better legibility on the new background

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: missing peer dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d811065d308320a9905b94ae0ec33c