### PR TITLE
Restrict mismatch tooltip mount to status cell

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -227,16 +227,32 @@ body.admin-theme {
 .admin-page .status-mismatch {
     display: inline-flex;
     align-items: center;
-    margin-left: 4px
+    margin-left: 6px
     }
 .admin-page .status-mismatch-icon {
     color: #ff4d4f;
-    font-size: 14px;
+    font-size: 12px;
     line-height: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    cursor: help
+    cursor: help;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    font-weight: 700;
+    box-shadow: 0 0 0 1px rgba(255, 77, 79, 0.2);
+    flex-shrink: 0
+    }
+.admin-page tr.summary-row.status-mismatch-row {
+    background: rgba(255, 77, 79, 0.12)
+    }
+.admin-page tr.summary-row.status-mismatch-row.expandable:hover {
+    background: rgba(255, 77, 79, 0.18)
+    }
+.admin-page tr.summary-row.status-mismatch-row.expanded {
+    background: rgba(255, 77, 79, 0.18)
     }
 .admin-page tr.summary-row .row-toggle::before {
     content: '▸';

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -1427,7 +1427,9 @@ ${cellsHtml}
 
   function setupStatusMismatchTooltips() {
     if (!tbody) return;
-    const tooltipTargets = tbody.querySelectorAll('[data-status-mismatch="true"]');
+    const tooltipTargets = tbody.querySelectorAll(
+      '.status-mismatch[data-status-mismatch="true"]'
+    );
     if (!tooltipTargets.length) return;
     tooltipTargets.forEach((target) => {
       const message =
@@ -1448,7 +1450,7 @@ ${cellsHtml}
                     role: 'img',
                     'aria-label': message,
                   },
-                  '✖'
+                  '!'
                 ),
             }
           );
@@ -1463,7 +1465,14 @@ ${cellsHtml}
     if (!tbody) return;
     cleanupStatusMismatchTooltips();
     const tooltipMessage = getStatusMismatchTooltipMessage();
+    const processedRows = new Set();
     tbody.querySelectorAll('td[data-raw-status]').forEach((td) => {
+      const summaryRow = td.closest('tr.summary-row');
+      if (summaryRow && !processedRows.has(summaryRow)) {
+        summaryRow.classList.remove('status-mismatch-row');
+        summaryRow.removeAttribute('data-status-mismatch');
+        processedRows.add(summaryRow);
+      }
       const raw = td.getAttribute('data-raw-status') || '';
       const canonical = normalizeStatusValue(raw);
       const value = canonical || raw;
@@ -1481,6 +1490,10 @@ ${cellsHtml}
         indicator.setAttribute('data-status-mismatch', 'true');
         indicator.setAttribute('data-tooltip-message', tooltipMessage);
         td.appendChild(indicator);
+        if (summaryRow) {
+          summaryRow.classList.add('status-mismatch-row');
+          summaryRow.setAttribute('data-status-mismatch', 'true');
+        }
       }
     });
     setupStatusMismatchTooltips();


### PR DESCRIPTION
## Summary
- scope status mismatch tooltip mounting to the dedicated indicator element so the icon only renders in the status cell

## Testing
- npm run build *(fails: Rollup cannot resolve ant-design-vue in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d811065d308320a9905b94ae0ec33c