### PR TITLE
Remove window.APP_CONFIG configuration fallback

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Backend API base URL (e.g., https://api.example.com)
+VITE_API_BASE=
+
+# Mapbox access token used for route calculations
+VITE_MAPBOX_ACCESS_TOKEN=
+
+# Dynamsoft barcode scanner license key
+VITE_DYNAMSOFT_LICENSE_KEY=

--- a/README.md
+++ b/README.md
@@ -23,4 +23,15 @@ npm run build
 
 The production bundle is emitted to `dist/`.
 
-Environment-specific API endpoints can be injected by overriding `window.APP_CONFIG.API_BASE` (for example, via `dist/config.js`).
+## Configuration
+
+Sensitive values such as API endpoints and third-party keys are loaded from environment variables.
+Create a `.env` file (or copy `.env` to `.env.local`) and provide the values appropriate for your environment:
+
+```
+VITE_API_BASE=https://api.example.com
+VITE_MAPBOX_ACCESS_TOKEN=pk.your-mapbox-token
+VITE_DYNAMSOFT_LICENSE_KEY=your-dynamsoft-license
+```
+
+These variables are read at build time by Vite. Ensure any deployment platform exposes the `VITE_*` variables during the build step so the application can access them at runtime.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Jakarta SCM</title>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <script src="/config.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dynamsoft-javascript-barcode@9.6.40/dist/dbr.js"></script>
   </head>
   <body>

--- a/public/config.js
+++ b/public/config.js
@@ -1,5 +1,0 @@
-// public/config.js
-window.APP_CONFIG = {
-  // 本地调试用 API 地址，可以改成 http://localhost:3000 或者后端真实地址
-  API_BASE: "https://back.idnsc.dpdns.org"
-};

--- a/render.yaml
+++ b/render.yaml
@@ -2,16 +2,15 @@ services:
   - type: static
     name: your-static-site
     envVars:
-      - key: API_BASE
+      - key: VITE_API_BASE
+        sync: false
+      - key: VITE_MAPBOX_ACCESS_TOKEN
+        sync: false
+      - key: VITE_DYNAMSOFT_LICENSE_KEY
         sync: false
     buildCommand: |
       npm install
       npm run build
-      cat > dist/config.js <<EOCONFIG
-      window.APP_CONFIG = {
-        API_BASE: "${API_BASE}"
-      };
-      EOCONFIG
     staticPublishPath: dist
     routes:
       # Fallback rewrite so SPA routes load correctly on direct visits

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,38 @@
+const toTrimmedString = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : '';
+};
+
+const readImportMetaEnv = (key) => {
+  if (typeof key !== 'string' || !key) return '';
+  try {
+    const value = import.meta.env?.[key];
+    return toTrimmedString(value);
+  } catch (_error) {
+    return '';
+  }
+};
+
+export const getApiBase = () => {
+  const envValue = readImportMetaEnv('VITE_API_BASE');
+  if (envValue) return envValue;
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return toTrimmedString(window.location.origin) || '';
+  }
+
+  return '';
+};
+
+export const getMapboxAccessToken = () => {
+  const envValue = readImportMetaEnv('VITE_MAPBOX_ACCESS_TOKEN');
+  if (envValue) return envValue;
+  return '';
+};
+
+export const getDynamsoftLicenseKey = () => {
+  const envValue = readImportMetaEnv('VITE_DYNAMSOFT_LICENSE_KEY');
+  if (envValue) return envValue;
+  return '';
+};

--- a/src/views/RouteCalculatorView.vue
+++ b/src/views/RouteCalculatorView.vue
@@ -75,9 +75,13 @@
 import { computed, nextTick, ref } from 'vue';
 import * as XLSX from 'xlsx';
 import { useBodyTheme } from '../composables/useBodyTheme';
+import { getMapboxAccessToken } from '../utils/env.js';
 
-const MAPBOX_ACCESS_TOKEN =
-  'pk.eyJ1IjoicnFiMjR2cDIiLCJhIjoiY201dGlodTU3MHcyYzJqcTBoN3BsdDA4NiJ9.YSHAPavjlOhdbKx8Z7gPWA';
+const MAPBOX_ACCESS_TOKEN = getMapboxAccessToken();
+
+if (!MAPBOX_ACCESS_TOKEN) {
+  console.warn('Mapbox access token is not configured. Route calculations will fail.');
+}
 
 useBodyTheme(null);
 
@@ -245,6 +249,10 @@ const processRowsSequentially = async () => {
 };
 
 const fetchRoute = async (origin, destination) => {
+  if (!MAPBOX_ACCESS_TOKEN) {
+    throw new Error('Mapbox access token is not configured');
+  }
+
   const url = new URL(
     `https://api.mapbox.com/directions/v5/mapbox/driving/${origin.lon},${origin.lat};${destination.lon},${destination.lat}`
   );

--- a/src/views/ScanView.vue
+++ b/src/views/ScanView.vue
@@ -190,12 +190,14 @@ import Toastify from 'toastify-js';
 import { createI18n } from '../i18n/core';
 import { useBodyTheme } from '../composables/useBodyTheme';
 import LanguageSwitcher from '../components/LanguageSwitcher.vue';
+import { getApiBase, getDynamsoftLicenseKey } from '../utils/env.js';
 
-const LICENSE_KEY =
-  'DLS2eyJoYW5kc2hha2VDb2RlIjoiMTA0NTQzNDEwLU1UQTBOVFF6TkRFd0xYZGxZaTFVY21saGJGQnliMm8iLCJtYWluU2VydmVyVVJMIjoiaHR0cHM6Ly9tZGxzLmR5bmFtc29mdG9ubGluZS5jb20iLCJvcmdhbml6YXRpb25JRCI6IjEwNDU0MzQxMCIsInN0YW5kYnlTZXJ2ZXJVUkwiOiJodHRwczovL3NkbHMuZHluYW1zb2Z0b25saW5lLmNvbSIsImNoZWNrQ29kZSI6MTg2NjI4MDUzMX0=';
+const LICENSE_KEY = getDynamsoftLicenseKey();
 
-if (window?.Dynamsoft?.DBR?.BarcodeScanner) {
+if (LICENSE_KEY && window?.Dynamsoft?.DBR?.BarcodeScanner) {
   window.Dynamsoft.DBR.BarcodeScanner.license = LICENSE_KEY;
+} else if (!LICENSE_KEY) {
+  console.warn('Dynamsoft license key is not configured. Scanner features may be unavailable.');
 }
 
 const i18n = createI18n({
@@ -544,7 +546,7 @@ const submitUpdate = async () => {
   state.submitOk = false;
 
   try {
-    const API_BASE = (window.APP_CONFIG && window.APP_CONFIG.API_BASE) || '';
+    const API_BASE = getApiBase();
 
     if (!API_BASE) {
       await new Promise((r) => setTimeout(r, 300));

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -11,6 +11,7 @@ import {
   DN_SCAN_STATUS_VALUES,
   STATUS_DISPLAY_OVERRIDES,
 } from '../../config.js';
+import { getApiBase } from '../../utils/env.js';
 
 import { createDnEntryManager } from './dnEntry.js';
 import { createStatusCardManager } from './statusCards.js';
@@ -18,10 +19,7 @@ import { createFilterBridgeManager } from './filterBridgeManager.js';
 import { getTodayDateStringInTimezone } from './dateUtils.js';
 import { escapeHtml, setFormControlValue } from './utils.js';
 
-const API_BASE =
-  (window.APP_CONFIG && window.APP_CONFIG.API_BASE) ||
-  window.API_BASE ||
-  window.location.origin;
+const API_BASE = getApiBase();
 
 export function setupAdminPage(
   rootEl,

--- a/src/views/dashboard/setupDashboardPage.js
+++ b/src/views/dashboard/setupDashboardPage.js
@@ -1,3 +1,5 @@
+import { getApiBase } from '../../utils/env.js';
+
 const STATUS_ORDER = [
   'NEW MOS',
   'PREPARE VEHICLE',
@@ -31,9 +33,7 @@ const STATUS_INDEX = STATUS_ORDER.reduce((acc, key, idx) => {
   return acc;
 }, {});
 
-const API_BASE =
-  (window.APP_CONFIG && window.APP_CONFIG.API_BASE) ||
-  'https://back.idnsc.dpdns.org';
+const API_BASE = getApiBase();
 
 export function setupDashboardPage(rootEl, opts = {}) {
   if (!rootEl) {


### PR DESCRIPTION
## Summary
- remove the public config shim and all window.APP_CONFIG lookups in favour of import.meta.env VITE variables
- update documentation and deployment scaffolding to describe the VITE_* environment requirements

## Testing
- npm run build *(fails: missing ant-design-vue dependency in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fdb1bcd48320a94a1fb7af81e3d1