### PR TITLE
Add LSP summary cards to admin view

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -53,6 +53,65 @@ body.admin-theme {
     padding: 14px;
     margin-top: 14px
     }
+.admin-page .lsp-summary-card-section {
+    margin-bottom: 12px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(105, 168, 255, 0.08);
+    border: 1px solid rgba(105, 168, 255, 0.25);
+    overflow-x: auto;
+    scrollbar-width: thin
+    }
+.admin-page .lsp-summary-card-container {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: stretch
+    }
+.admin-page .lsp-summary-card {
+    appearance: none;
+    border: 1px solid #24345c;
+    border-radius: 999px;
+    background: rgba(11, 19, 40, 0.92);
+    color: #eaf2ff;
+    padding: 6px 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease
+    }
+.admin-page .lsp-summary-card:hover {
+    border-color: #69a8ff;
+    box-shadow: 0 0 0 1px rgba(105, 168, 255, 0.35)
+    }
+.admin-page .lsp-summary-card:focus-visible {
+    outline: 2px solid rgba(105, 168, 255, 0.75);
+    outline-offset: 2px
+    }
+.admin-page .lsp-summary-card.active {
+    border-color: #69a8ff;
+    background: rgba(105, 168, 255, 0.22);
+    box-shadow: 0 0 0 1px rgba(105, 168, 255, 0.45)
+    }
+.admin-page .lsp-summary-card.loading {
+    cursor: progress;
+    opacity: 0.7
+    }
+.admin-page .lsp-summary-card__label {
+    font-weight: 600;
+    color: #cfe2ff
+    }
+.admin-page .lsp-summary-card__stats {
+    color: #9cc6ff
+    }
+.admin-page .lsp-summary-card--placeholder {
+    cursor: progress;
+    opacity: 0.7
+    }
 .admin-page .status-card-section {
     margin-bottom: 12px
     }

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -271,6 +271,15 @@
       </div>
 
       <div class="card">
+        <div
+          id="lsp-summary-card-wrapper"
+          class="lsp-summary-card-section"
+          style="display: none"
+          role="group"
+          aria-hidden="true"
+        >
+          <div id="lsp-summary-card-container" class="lsp-summary-card-container"></div>
+        </div>
         <div id="hint" class="muted" data-i18n="hint.ready">输入条件后点击查询。</div>
         <table id="tbl" style="display: none">
           <thead>

--- a/src/views/admin/lspSummaryCards.js
+++ b/src/views/admin/lspSummaryCards.js
@@ -1,0 +1,172 @@
+const normalizeLspName = (raw) => {
+  if (!raw && raw !== 0) return '';
+  const str = typeof raw === 'string' ? raw : String(raw ?? '').trim();
+  return str.trim();
+};
+
+const normalizeNumber = (raw, fallback = 0) => {
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+export function createLspSummaryCardManager({
+  container,
+  wrapper,
+  signal,
+  onCardClick,
+  getActiveLspValues,
+} = {}) {
+  let summaries = [];
+  let loading = false;
+  const refs = new Map();
+
+  const getActiveSet = () => {
+    if (typeof getActiveLspValues !== 'function') return new Set();
+    try {
+      const values = getActiveLspValues();
+      if (!values) return new Set();
+      const array = Array.isArray(values) ? values : [values];
+      return new Set(
+        array
+          .map((item) => normalizeLspName(item))
+          .filter((item) => Boolean(item))
+      );
+    } catch (err) {
+      console.error(err);
+    }
+    return new Set();
+  };
+
+  const attachCardHandler = (button, item) => {
+    if (!button) return;
+    button.addEventListener(
+      'click',
+      () => {
+        if (!item) return;
+        onCardClick?.(item);
+      },
+      { signal }
+    );
+  };
+
+  const renderEmptyState = () => {
+    if (!wrapper || !container) return;
+    container.innerHTML = '';
+    refs.clear();
+    if (loading) {
+      wrapper.style.display = '';
+      wrapper.setAttribute('aria-hidden', 'false');
+      wrapper.setAttribute('aria-busy', 'true');
+      const placeholder = document.createElement('div');
+      placeholder.className = 'lsp-summary-card lsp-summary-card--placeholder';
+      placeholder.setAttribute('aria-hidden', 'true');
+      placeholder.textContent = 'Loading…';
+      container.appendChild(placeholder);
+    } else {
+      wrapper.style.display = 'none';
+      wrapper.setAttribute('aria-hidden', 'true');
+      wrapper.removeAttribute('aria-busy');
+    }
+  };
+
+  const renderCards = () => {
+    if (!wrapper || !container) return;
+    container.innerHTML = '';
+    refs.clear();
+
+    if (!summaries.length) {
+      renderEmptyState();
+      return;
+    }
+
+    wrapper.style.display = '';
+    wrapper.setAttribute('aria-hidden', 'false');
+    wrapper.setAttribute('aria-busy', loading ? 'true' : 'false');
+
+    const activeSet = getActiveSet();
+
+    summaries.forEach((item) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'lsp-summary-card';
+      btn.setAttribute('data-lsp', item.lsp);
+      btn.setAttribute('aria-pressed', activeSet.has(item.lsp) ? 'true' : 'false');
+      btn.setAttribute('aria-busy', loading ? 'true' : 'false');
+
+      const label = document.createElement('span');
+      label.className = 'lsp-summary-card__label';
+      label.textContent = `${item.lsp}:`;
+
+      const stats = document.createElement('span');
+      stats.className = 'lsp-summary-card__stats';
+      stats.textContent = `Updated ${item.updated}/${item.total} Total`;
+
+      btn.setAttribute('aria-label', `${item.lsp}: Updated ${item.updated}/${item.total} Total`);
+
+      btn.appendChild(label);
+      btn.appendChild(stats);
+
+      container.appendChild(btn);
+      refs.set(item.lsp, { button: btn, item });
+      attachCardHandler(btn, item);
+    });
+
+    updateActiveState();
+  };
+
+  function normalizeSummaries(list) {
+    if (!Array.isArray(list)) return [];
+    const normalized = [];
+    list.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') return;
+      const lsp = normalizeLspName(entry.lsp ?? entry.lsp_name ?? entry.name);
+      if (!lsp) return;
+      const updated = normalizeNumber(entry.status_not_empty ?? entry.updated ?? entry.count);
+      const total = normalizeNumber(entry.total_dn ?? entry.total ?? entry.total_count);
+      normalized.push({
+        lsp,
+        updated,
+        total,
+      });
+    });
+    return normalized.length
+      ? normalized
+      : [];
+  }
+
+  function setData(list) {
+    summaries = normalizeSummaries(list);
+    renderCards();
+  }
+
+  function setLoading(next) {
+    loading = Boolean(next);
+    if (!summaries.length) {
+      renderEmptyState();
+      return;
+    }
+    wrapper?.setAttribute('aria-busy', loading ? 'true' : 'false');
+    refs.forEach(({ button }) => {
+      if (!button) return;
+      button.setAttribute('aria-busy', loading ? 'true' : 'false');
+      button.classList.toggle('loading', loading);
+    });
+  }
+
+  function updateActiveState() {
+    if (!refs.size) return;
+    const activeSet = getActiveSet();
+    refs.forEach(({ button, item }) => {
+      if (!button || !item) return;
+      const isActive = activeSet.has(item.lsp);
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  return {
+    setData,
+    setLoading,
+    updateActiveState,
+  };
+}


### PR DESCRIPTION
## Summary
- add a compact LSP summary card strip above the admin table with dedicated styling
- reuse the status delivery stats request to feed new LSP summary cards and keep their loading state in sync
- enable one-click filtering from the LSP cards to reset filters, default to today, and focus on the chosen LSP

## Testing
- npm run build *(fails: Rollup cannot resolve optional dependencies such as ant-design-vue)*

------
https://chatgpt.com/codex/tasks/task_e_68da229b7bd88320a20841286ec0f3a4