### PR TITLE
Add DN map view for transport managers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "ant-design-vue": "^4.2.6",
         "dayjs": "^1.11.18",
+        "mapbox-gl": "^2.15.0",
         "toastify-js": "1.12.0",
         "v-viewer": "3.0.11",
         "viewerjs": "1.11.6",
@@ -523,6 +524,69 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.3",
@@ -1455,6 +1519,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1498,6 +1568,12 @@
       "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-2.0.1.tgz",
       "integrity": "sha512-bvVTQe1lfaUr1oFzZX80ce9KLDlZ3iU+XGNE/bz9HnGdklTieqsbmsLHe+rT2XWqopvL0PckkYqN7ksmm5pe3w==",
       "license": "MIT"
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -1625,11 +1701,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "license": "ISC"
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1637,6 +1718,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1657,6 +1750,26 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1759,6 +1872,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1790,6 +1909,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mapbox-gl": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.15.0.tgz",
+      "integrity": "sha512-fjv+aYrd5TIHiL7wRa+W7KjtUqKWziJMZUkK5hm8TvJ3OLeNPx4NmW/DgfYhd/jHej8wWL+QJBDbdMMAKvNC0A==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^2.0.1",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.4",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.4.3",
+        "grid-index": "^1.1.0",
+        "kdbush": "^4.0.1",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^8.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
       }
     },
     "node_modules/merge-stream": {
@@ -1859,7 +2008,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1870,6 +2018,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1969,6 +2123,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2003,6 +2170,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2012,6 +2191,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
     },
     "node_modules/range-parser": {
       "version": "1.2.0",
@@ -2079,6 +2264,15 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
@@ -2120,6 +2314,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2320,6 +2520,15 @@
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2341,6 +2550,12 @@
       "engines": {
         "node": ">=12.22"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/toastify-js": {
       "version": "1.12.0",
@@ -2465,6 +2680,17 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "ant-design-vue": "^4.2.6",
     "dayjs": "^1.11.18",
+    "mapbox-gl": "^2.15.0",
     "toastify-js": "1.12.0",
     "v-viewer": "3.0.11",
     "viewerjs": "1.11.6",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,11 @@ const routes = [
     name: 'routes',
     component: () => import('../views/RouteCalculatorView.vue'),
   },
+  {
+    path: '/map',
+    name: 'map',
+    component: () => import('../views/MapView.vue'),
+  },
 ];
 
 const router = createRouter({

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -5,6 +5,14 @@
         <LanguageSwitcher v-model="currentLang" @change="changeLang" />
         <div class="auth-area">
           <span id="auth-role-tag" class="role-tag" data-i18n="auth.current"></span>
+          <button
+            v-if="showMapViewButton"
+            type="button"
+            class="btn ghost"
+            @click="openMapView"
+          >
+            地图视图
+          </button>
           <button class="btn ghost accent" id="btn-auth" data-i18n="auth.trigger">
             授权
           </button>
@@ -419,6 +427,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { Switch } from 'ant-design-vue';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { useRouter } from 'vue-router';
 import { createI18n } from '../i18n/core';
 import { applyI18n } from '../i18n/dom';
 import { setupAdminPage } from './admin/setupAdminPage';
@@ -433,6 +442,12 @@ dayjs.extend(customParseFormat);
 
 const adminRoot = ref(null);
 const currentLang = ref('zh');
+const currentRoleKey = ref('');
+const router = useRouter();
+const TRANSPORT_MANAGER_ROLE_KEY = 'transportManager';
+const showMapViewButton = computed(
+  () => currentRoleKey.value === TRANSPORT_MANAGER_ROLE_KEY
+);
 let pageCleanup = () => {};
 let i18nInstance = null;
 
@@ -479,6 +494,14 @@ const {
 } = useAdminFilters();
 
 useBodyTheme('admin-theme');
+
+const openMapView = () => {
+  const resolved = router.resolve({ name: 'map' });
+  const href = resolved?.href || resolved?.fullPath || '/map';
+  if (typeof window !== 'undefined') {
+    window.open(href, '_blank', 'noopener');
+  }
+};
 
 const filterSelectOption = (input, option) => {
   const text = `${option?.label ?? option?.value ?? ''}`.toLowerCase();
@@ -593,6 +616,9 @@ onMounted(async () => {
     planMosDateSelect: planMosDateSelectBridge,
     filterSelects: filterSelectBridges,
     filterInputs: filterInputBridges,
+    onRoleChange: (roleKey) => {
+      currentRoleKey.value = roleKey || '';
+    },
   });
 
   i18nInstance.onChange((lang) => {

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -1,0 +1,502 @@
+<template>
+  <div class="map-view">
+    <aside class="map-view__sidebar">
+      <header class="sidebar-header">
+        <h1>DN 地图视图</h1>
+        <p class="sidebar-summary">
+          共 <strong>{{ dnItems.length }}</strong> 条记录
+        </p>
+      </header>
+      <div class="sidebar-content" role="status" aria-live="polite">
+        <div v-if="isLoading" class="sidebar-state">正在加载数据…</div>
+        <div v-else-if="error" class="sidebar-state sidebar-state--error">{{ error }}</div>
+        <div v-else-if="!dnItems.length" class="sidebar-state">暂无 DN 数据</div>
+        <ul v-else class="dn-list">
+          <li
+            v-for="item in dnItems"
+            :key="item.id || item.dn_number"
+            class="dn-card"
+            :class="{ 'dn-card--on-site': isOnSiteStatus(item.status) }"
+          >
+            <div class="dn-card__header">
+              <span class="dn-number">{{ item.dn_number || '未命名 DN' }}</span>
+              <span
+                class="status-tag"
+                :class="{ 'status-tag--on-site': isOnSiteStatus(item.status) }"
+              >
+                {{ item.status || '未填写' }}
+              </span>
+            </div>
+            <div class="dn-card__meta">
+              <div class="meta-row">
+                <span class="meta-label">Region</span>
+                <span class="meta-value">{{ formatField(item.region) }}</span>
+              </div>
+              <div class="meta-row">
+                <span class="meta-label">LSP</span>
+                <span class="meta-value">{{ formatField(item.lsp) }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </aside>
+    <section class="map-view__map" aria-live="polite">
+      <div v-if="!mapboxToken" class="map-placeholder">
+        未配置 Mapbox access token，无法展示地图。
+      </div>
+      <div v-else ref="mapContainer" class="map-canvas"></div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
+import mapboxgl from 'mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import { getApiBase, getMapboxAccessToken } from '../utils/env';
+
+const mapboxToken = getMapboxAccessToken();
+
+const dnItems = ref([]);
+const isLoading = ref(false);
+const error = ref('');
+
+const mapContainer = ref(null);
+const mapInstance = shallowRef(null);
+const mapLoaded = ref(false);
+const activeMarkers = [];
+let pendingMarkerData = null;
+
+const apiBase = getApiBase();
+
+const buildRequestUrl = (page) => {
+  const params = new URLSearchParams({
+    status_not_empty: 'true',
+    date: '29 Sep 25',
+    page: String(page),
+  });
+
+  if (apiBase) {
+    const url = new URL('/api/dn/list/search', apiBase);
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  return `/api/dn/list/search?${params.toString()}`;
+};
+
+const normalizeNumber = (value) => {
+  const num = Number.parseFloat(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const isOnSiteStatus = (status) => {
+  if (!status) return false;
+  return String(status).trim().toLowerCase() === 'on site';
+};
+
+const formatField = (value) => {
+  if (value === undefined || value === null) return '—';
+  const text = String(value).trim();
+  return text.length ? text : '—';
+};
+
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatForPopup = (value, fallback = '—') => {
+  const formatted = formatField(value);
+  const text = formatted === '—' ? fallback : formatted;
+  return escapeHtml(text);
+};
+
+const mapPoints = computed(() => {
+  return dnItems.value
+    .map((item) => {
+      const lat = normalizeNumber(item.lat);
+      const lng = normalizeNumber(item.lng);
+      if (lat === null || lng === null) return null;
+      return {
+        id: item.id,
+        dnNumber: item.dn_number,
+        status: item.status,
+        region: item.region,
+        lsp: item.lsp,
+        latitude: lat,
+        longitude: lng,
+        isOnSite: isOnSiteStatus(item.status),
+      };
+    })
+    .filter(Boolean);
+});
+
+const clearMarkers = () => {
+  while (activeMarkers.length) {
+    const marker = activeMarkers.pop();
+    try {
+      marker.remove();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+};
+
+const updateMarkers = (points) => {
+  if (!mapInstance.value || !mapLoaded.value) return;
+  clearMarkers();
+  if (!Array.isArray(points) || !points.length) return;
+
+  const bounds = new mapboxgl.LngLatBounds();
+
+  points.forEach((point) => {
+    const marker = new mapboxgl.Marker({
+      color: point.isOnSite ? '#22c55e' : '#2563eb',
+    })
+      .setLngLat([point.longitude, point.latitude])
+      .setPopup(
+        new mapboxgl.Popup({ offset: 24 }).setHTML(
+          `
+            <div class="marker-popup">
+              <strong>${formatForPopup(point.dnNumber, 'DN 未命名')}</strong>
+              <div>状态：${formatForPopup(point.status, '未填写')}</div>
+              <div>Region：${formatForPopup(point.region)}</div>
+              <div>LSP：${formatForPopup(point.lsp)}</div>
+            </div>
+          `.trim()
+        )
+      )
+      .addTo(mapInstance.value);
+
+    activeMarkers.push(marker);
+    bounds.extend([point.longitude, point.latitude]);
+  });
+
+  if (points.length === 1) {
+    mapInstance.value.easeTo({
+      center: [points[0].longitude, points[0].latitude],
+      zoom: 9,
+      duration: 800,
+    });
+  } else {
+    mapInstance.value.fitBounds(bounds, {
+      padding: 64,
+      maxZoom: 10,
+      duration: 800,
+    });
+  }
+};
+
+const scheduleMarkerUpdate = (points) => {
+  if (!mapInstance.value) {
+    pendingMarkerData = points;
+    return;
+  }
+
+  if (!mapLoaded.value) {
+    pendingMarkerData = points;
+    return;
+  }
+
+  updateMarkers(points);
+};
+
+const initializeMap = () => {
+  if (!mapboxToken || !mapContainer.value) return;
+
+  mapboxgl.accessToken = mapboxToken;
+
+  const map = new mapboxgl.Map({
+    container: mapContainer.value,
+    style: 'mapbox://styles/mapbox/streets-v11',
+    center: [106.8456, -6.2088],
+    zoom: 5,
+  });
+
+  map.addControl(new mapboxgl.NavigationControl({ visualizePitch: true }));
+
+  map.on('load', () => {
+    mapLoaded.value = true;
+    updateMarkers(pendingMarkerData || mapPoints.value);
+    pendingMarkerData = null;
+  });
+
+  mapInstance.value = map;
+};
+
+const fetchAllDnItems = async () => {
+  isLoading.value = true;
+  error.value = '';
+  dnItems.value = [];
+
+  try {
+    const aggregated = [];
+    let total = Infinity;
+    let page = 1;
+
+    while (aggregated.length < total) {
+      const response = await fetch(buildRequestUrl(page));
+      let payload;
+      try {
+        payload = await response.json();
+      } catch (err) {
+        throw new Error('无法解析服务器返回的数据');
+      }
+
+      if (!response.ok || payload?.ok === false) {
+        const message =
+          payload?.message || payload?.msg || `请求失败（${response.status}）`;
+        throw new Error(message);
+      }
+
+      const items = Array.isArray(payload?.items) ? payload.items : [];
+      aggregated.push(...items);
+
+      const reportedTotal = Number(payload?.total);
+      if (Number.isFinite(reportedTotal) && reportedTotal >= 0) {
+        total = reportedTotal;
+      }
+
+      const pageSize = Number(payload?.page_size);
+      if (!items.length || (Number.isFinite(pageSize) && items.length < pageSize)) {
+        break;
+      }
+
+      page += 1;
+      if (page > 200) {
+        break;
+      }
+    }
+
+    dnItems.value = aggregated;
+    scheduleMarkerUpdate(mapPoints.value);
+  } catch (err) {
+    console.error(err);
+    error.value = err?.message || '加载 DN 数据失败';
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+watch(
+  mapPoints,
+  (points) => {
+    scheduleMarkerUpdate(points);
+  },
+  { deep: false }
+);
+
+onMounted(() => {
+  if (mapboxToken) {
+    initializeMap();
+  }
+  fetchAllDnItems();
+});
+
+onBeforeUnmount(() => {
+  clearMarkers();
+  if (mapInstance.value) {
+    try {
+      mapInstance.value.remove();
+    } catch (err) {
+      console.error(err);
+    }
+    mapInstance.value = null;
+  }
+});
+</script>
+
+<style scoped>
+.map-view {
+  display: grid;
+  grid-template-columns: minmax(320px, 360px) 1fr;
+  height: 100vh;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.map-view__sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #e2e8f0;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  padding: 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.sidebar-header h1 {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.sidebar-summary {
+  margin: 0;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.sidebar-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-state {
+  padding: 16px;
+  border-radius: 12px;
+  background: #f1f5f9;
+  color: #475569;
+  text-align: center;
+  font-size: 14px;
+}
+
+.sidebar-state--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.dn-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dn-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 16px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dn-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.dn-card--on-site {
+  border-color: #22c55e;
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.15);
+}
+
+.dn-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+
+.dn-number {
+  font-weight: 600;
+  font-size: 16px;
+  color: #0f172a;
+  word-break: break-all;
+}
+
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.status-tag--on-site {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.dn-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.meta-label {
+  color: #64748b;
+}
+
+.meta-value {
+  color: #0f172a;
+  text-align: right;
+}
+
+.map-view__map {
+  position: relative;
+}
+
+.map-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.map-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  color: #b91c1c;
+  height: 100%;
+  background: #fef2f2;
+  font-weight: 500;
+}
+
+.marker-popup {
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.marker-popup strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+@media (max-width: 960px) {
+  .map-view {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .map-view__sidebar {
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
+  }
+
+  .map-canvas {
+    min-height: 400px;
+  }
+}
+</style>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -93,7 +93,8 @@ const normalizeNumber = (value) => {
 
 const isOnSiteStatus = (status) => {
   if (!status) return false;
-  return String(status).trim().toLowerCase() === 'on site';
+  const normalized = String(status).trim().toLowerCase();
+  return normalized === 'on site' || normalized === 'arrived at site';
 };
 
 const formatField = (value) => {

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -24,7 +24,14 @@ const API_BASE = getApiBase();
 
 export function setupAdminPage(
   rootEl,
-  { i18n, applyTranslations, planMosDateSelect, filterSelects, filterInputs } = {}
+  {
+    i18n,
+    applyTranslations,
+    planMosDateSelect,
+    filterSelects,
+    filterInputs,
+    onRoleChange,
+  } = {}
 ) {
   if (!rootEl) return () => {};
 
@@ -110,6 +117,15 @@ export function setupAdminPage(
   const TRANSPORT_MANAGER_ROLE_KEY = 'transportManager';
   const ARCHIVE_THRESHOLD_DAYS = 55;
   const AUTH_STORAGE_KEY = 'jakarta-admin-auth-state';
+
+  const notifyRoleChange = (roleKey, role) => {
+    if (typeof onRoleChange !== 'function') return;
+    try {
+      onRoleChange(roleKey || '', role || null);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   const STATUS_VALUE_TO_KEY = STATUS_TRANSLATION_KEYS || {};
   const STATUS_ALIAS_LOOKUP = STATUS_ALIAS_MAP || {};
@@ -1252,6 +1268,8 @@ ${cellsHtml}
     statusCards.refreshCounts();
     lspSummaryCards.updateActiveState();
     persistAuthState(currentRoleKey, currentUserInfo);
+    const role = currentRoleKey ? ROLE_MAP.get(currentRoleKey) || null : null;
+    notifyRoleChange(currentRoleKey || '', role);
   }
 
   function getRoleLabel(role) {
@@ -2874,6 +2892,7 @@ ${cellsHtml}
       rerenderTableActions();
       statusCards.render();
       statusCards.refreshCounts();
+      notifyRoleChange('', null);
     }
   }
 


### PR DESCRIPTION
## Summary
- add a MapView page that aggregates DN search results, shows record details, and renders Mapbox markers with on-site coloring
- expose the map route through the router and add a transport-manager-only button in the admin header that opens the map in a new tab
- allow the admin setup script to report role changes so the Vue view can react to transport-manager logins

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da3cd60e7c8320bf1c894e0b829a17