### PR TITLE
Stop applying status filter on status card clicks

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -1698,11 +1698,9 @@ ${cellsHtml}
     setFilterValue('subcon', '');
     setFilterValue('status_wh', '');
 
-    if (targetStatus) {
-      setFilterValue('status', targetStatus);
-    } else {
-      setFilterValue('status', '');
-    }
+    // Clicking a status card should only apply the status_delivery filter.
+    // Keep the status filter cleared so the query does not constrain by status.
+    setFilterValue('status', '');
 
     setFilterValue('status_delivery', targetStatus);
 


### PR DESCRIPTION
## Summary
- prevent status card selection from applying the status filter so queries rely on status_delivery only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da73d756048320bb4ea8991e359c47