### PR TITLE
Add LSP summary chart modal to map view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jakartascmfront",
       "version": "1.0.0",
       "dependencies": {
+        "@ant-design/plots": "^2.6.5",
         "ant-design-vue": "^4.2.6",
         "dayjs": "^1.11.18",
         "mapbox-gl": "^2.15.0",
@@ -22,6 +23,19 @@
         "@vitejs/plugin-vue": "5.0.4",
         "serve": "^14.2.5",
         "vite": "5.2.13"
+      }
+    },
+    "node_modules/@ant-design/charts-util": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/charts-util/-/charts-util-0.0.2.tgz",
+      "integrity": "sha512-JuThvtHE8R3PldXzTkL3bmmFf0HVhih49CYinRrkwgovOmvDYaaKHnI53EWJbW8n4Ndcyy8jiZTSkoxcjGS6Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
       }
     },
     "node_modules/@ant-design/colors": {
@@ -50,6 +64,391 @@
       },
       "peerDependencies": {
         "vue": ">=3.0.3"
+      }
+    },
+    "node_modules/@ant-design/plots": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-2.6.5.tgz",
+      "integrity": "sha512-lzYMQdb5TWWfi/RnHpuJ9Iu3/WR8OJj2lYcyBlBOkCghOLstNw6sYSbGMGDIzPKp1AS1Fvomw5KwZzD/mdiykA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/charts-util": "0.0.2",
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/g": "^6.1.7",
+        "@antv/g2": "^5.2.7",
+        "@antv/g2-extension-plot": "^0.2.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.4",
+        "react-dom": ">=16.8.4"
+      }
+    },
+    "node_modules/@antv/component": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@antv/component/-/component-2.1.7.tgz",
+      "integrity": "sha512-vuSuSjKFsWZBD77ZjMoP9c+FhMQvkJvPJb0dFR8Ym5kr44gfc437QE9rhuemlcjN8KEpPtMZtnUk/p6WB5qdOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g": "^6.1.11",
+        "@antv/scale": "^0.4.16",
+        "@antv/util": "^3.3.10",
+        "svg-path-parser": "^1.1.0"
+      }
+    },
+    "node_modules/@antv/component/node_modules/@antv/scale": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.4.16.tgz",
+      "integrity": "sha512-5wg/zB5kXHxpTV5OYwJD3ja6R8yTiqIOkjOhmpEJiowkzRlbEC/BOyMvNUq5fqFIHnMCE9woO7+c3zxEQCKPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/coord": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@antv/coord/-/coord-0.4.7.tgz",
+      "integrity": "sha512-UTbrMLhwJUkKzqJx5KFnSRpU3BqrdLORJbwUbHK2zHSCT3q3bjcFA//ZYLVfIlwqFDXp/hzfMyRtp0c77A9ZVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/scale": "^0.4.12",
+        "@antv/util": "^2.0.13",
+        "gl-matrix": "^3.4.3"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/scale": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.4.16.tgz",
+      "integrity": "sha512-5wg/zB5kXHxpTV5OYwJD3ja6R8yTiqIOkjOhmpEJiowkzRlbEC/BOyMvNUq5fqFIHnMCE9woO7+c3zxEQCKPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/scale/node_modules/@antv/util": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-3.3.11.tgz",
+      "integrity": "sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "gl-matrix": "^3.3.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@antv/coord/node_modules/@antv/util": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-2.0.17.tgz",
+      "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
+      "license": "ISC",
+      "dependencies": {
+        "csstype": "^3.0.8",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@antv/event-emitter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@antv/event-emitter/-/event-emitter-0.1.3.tgz",
+      "integrity": "sha512-4ddpsiHN9Pd4UIlWuKVK1C4IiZIdbwQvy9i7DUSI3xNJ89FPUFt8lxDYj8GzzfdllV0NkJTRxnG+FvLk0llidg==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/expr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@antv/expr/-/expr-1.0.2.tgz",
+      "integrity": "sha512-vrfdmPHkTuiS5voVutKl2l06w1ihBh9A8SFdQPEE+2KMVpkymzGOF1eWpfkbGZ7tiFE15GodVdhhHomD/hdIwg==",
+      "license": "MIT"
+    },
+    "node_modules/@antv/g": {
+      "version": "6.1.28",
+      "resolved": "https://registry.npmjs.org/@antv/g/-/g-6.1.28.tgz",
+      "integrity": "sha512-BwavpbKGR4NEJD3BtVxfBFjCcxy5gsWoUNnBisfG1qfjhGTt7QvUYHFH46+mHJjHMIdYjuFw2T0ZYVtxBddxSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-camera-api": "2.0.41",
+        "@antv/g-dom-mutation-observer-api": "2.0.38",
+        "@antv/g-lite": "2.3.2",
+        "@antv/g-web-animations-api": "2.1.28",
+        "@babel/runtime": "^7.25.6"
+      }
+    },
+    "node_modules/@antv/g-camera-api": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@antv/g-camera-api/-/g-camera-api-2.0.41.tgz",
+      "integrity": "sha512-dF52/wpzHDKi7ZzPlaHurEjWrF9aBKL2udDwQkEeVtfkJ0DHaavr3BAvhuGhtHoecRYQJvpzP1OkGNDLQJQQlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-canvas": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/@antv/g-canvas/-/g-canvas-2.0.48.tgz",
+      "integrity": "sha512-P98cTLRbKbCAcUVgHqMjKcvOany6nR7wvt+g+sazIfKSMUCWgjLTOjlLezux2up3At29mt80StaV2AR3d61YQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/g-plugin-canvas-path-generator": "2.1.22",
+        "@antv/g-plugin-canvas-picker": "2.1.27",
+        "@antv/g-plugin-canvas-renderer": "2.3.3",
+        "@antv/g-plugin-dom-interaction": "2.1.27",
+        "@antv/g-plugin-html-renderer": "2.1.27",
+        "@antv/g-plugin-image-loader": "2.1.26",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-dom-mutation-observer-api": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@antv/g-dom-mutation-observer-api/-/g-dom-mutation-observer-api-2.0.38.tgz",
+      "integrity": "sha512-xzgbt8GUOiToBeDVv+jmGkDE+HtI9tD6uO8TirJbCya88DKcY/jurQALq0NdWKgMJLn7WPiUKyDwHWimwQcBJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@babel/runtime": "^7.25.6"
+      }
+    },
+    "node_modules/@antv/g-lite": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@antv/g-lite/-/g-lite-2.3.2.tgz",
+      "integrity": "sha512-fkIxRoqLOGsNPwsp26bPp58cPWuX3E4wQ9cfkB/DHy5LtLrPpvOwHWB3+MBPgZwzk8jTTjchiXa756ZFOAWyQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-math": "3.0.1",
+        "@antv/util": "^3.3.5",
+        "@antv/vendor": "^1.0.3",
+        "@babel/runtime": "^7.25.6",
+        "eventemitter3": "^5.0.1",
+        "gl-matrix": "^3.4.3",
+        "rbush": "^3.0.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-math": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@antv/g-math/-/g-math-3.0.1.tgz",
+      "integrity": "sha512-FvkDBNRpj+HsLINunrL2PW0OlG368MlpHuihbxleuajGim5kra8tgISwCLmAf8Yz2b1CgZ9PvpohqiLzHS7HLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-canvas-path-generator": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-canvas-path-generator/-/g-plugin-canvas-path-generator-2.1.22.tgz",
+      "integrity": "sha512-Z0IawzTGgTppa9IpkNNKsqgoU89oOjUsiU8GZZlkDkUggQTHP0wOxTeLAb43YgClx3aTI3bRs44uMQutNdSVxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/g-math": "3.0.1",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-canvas-picker": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-canvas-picker/-/g-plugin-canvas-picker-2.1.27.tgz",
+      "integrity": "sha512-DHQ0YLYNXAm6O63pW6nKs/R0fuqlUYfehNs/EtzrmqyUkKASd/Vhs4HLNeHTMUdBMgg41T+x5qay0GGttK4Xdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/g-math": "3.0.1",
+        "@antv/g-plugin-canvas-path-generator": "2.1.22",
+        "@antv/g-plugin-canvas-renderer": "2.3.3",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-canvas-renderer": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-canvas-renderer/-/g-plugin-canvas-renderer-2.3.3.tgz",
+      "integrity": "sha512-d6JkZy1YmLnvI9wsbO8QVpBz7z7tl6JRQkF5hx9XLDtf2fD4n83KINeMq13skiNwaiudS771WWiBtfzUHB73pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/g-math": "3.0.1",
+        "@antv/g-plugin-canvas-path-generator": "2.1.22",
+        "@antv/g-plugin-image-loader": "2.1.26",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-dom-interaction": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-dom-interaction/-/g-plugin-dom-interaction-2.1.27.tgz",
+      "integrity": "sha512-hltVZZH+bj0uXmGSR+6BIwhCFYyHmDIQi3vrj/Wn1Dn6PgufvMCXfjr3DfmkQnY+FFP8ZCpg5N9MaE0BE9OddA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-dragndrop": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-dragndrop/-/g-plugin-dragndrop-2.0.38.tgz",
+      "integrity": "sha512-yCef5ER759i0WpuOekFQ+AcDTu0N/COMbkPOG6YuswVnhQH447GUpuNm7Le+Mq26qONlXTDyjxuMHoUOWwJ7Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-html-renderer": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-html-renderer/-/g-plugin-html-renderer-2.1.27.tgz",
+      "integrity": "sha512-NnI4GxDBb71o/XZzoRdi0xI3xg7GJmthyO5xP5/MiOFmwJ/jW/QDz17vUonmzUVbCt6upikHV5GyYOaogRqdVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-plugin-image-loader": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/@antv/g-plugin-image-loader/-/g-plugin-image-loader-2.1.26.tgz",
+      "integrity": "sha512-AElV0QOX2LAhB3jr9XtvkynntuKhcaU5n7avu5ynM5VoAtMaJRANhCyefA2G3myeJxWcHk4nWDX6u4YMaZnnvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "gl-matrix": "^3.4.3",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g-web-animations-api": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@antv/g-web-animations-api/-/g-web-animations-api-2.1.28.tgz",
+      "integrity": "sha512-V5g8bO2D1hb8fRMMi5hXL/De+1UDRzW3C5EX07oazR0q71GONASP+sVwniZdt9R1HAmJSN5dvW3SqWeU3EEstQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/g-lite": "2.3.2",
+        "@antv/util": "^3.3.5",
+        "@babel/runtime": "^7.25.6",
+        "tslib": "^2.5.3"
+      }
+    },
+    "node_modules/@antv/g2": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-5.4.1.tgz",
+      "integrity": "sha512-G6wJDqipFT79uU5pNYfm5itH+9XD6KWhlMufvUjFX7W4Dm+VWt6JtANFqumS7NiECAdqHPcJTLF/Xxm8AxzYeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/component": "^2.1.3",
+        "@antv/coord": "^0.4.7",
+        "@antv/event-emitter": "^0.1.3",
+        "@antv/expr": "^1.0.2",
+        "@antv/g": "^6.1.24",
+        "@antv/g-canvas": "^2.0.43",
+        "@antv/g-plugin-dragndrop": "^2.0.35",
+        "@antv/scale": "^0.5.1",
+        "@antv/util": "^3.3.10",
+        "@antv/vendor": "^1.0.11",
+        "flru": "^1.0.2",
+        "pdfast": "^0.2.0"
+      }
+    },
+    "node_modules/@antv/g2-extension-plot": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@antv/g2-extension-plot/-/g2-extension-plot-0.2.2.tgz",
+      "integrity": "sha512-KJXCXO7as+h0hDqirGXf1omrNuYzQmY3VmBmp7lIvkepbQ7sz3pPwy895r1FWETGF3vTk5UeFcAF5yzzBHWgbw==",
+      "dependencies": {
+        "@antv/g2": "^5.1.8",
+        "@antv/util": "^3.3.5",
+        "@antv/vendor": "^1.0.10"
+      }
+    },
+    "node_modules/@antv/scale": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.5.2.tgz",
+      "integrity": "sha512-rTHRAwvpHWC5PGZF/mJ2ZuTDqwwvVBDRph0Uu5PV9BXwzV7K8+9lsqGJ+XHVLxe8c6bKog5nlzvV/dcYb0d5Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@antv/util": "^3.3.7",
+        "color-string": "^1.5.5",
+        "fecha": "^4.2.1"
+      }
+    },
+    "node_modules/@antv/util": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@antv/util/-/util-3.3.11.tgz",
+      "integrity": "sha512-FII08DFM4ABh2q5rPYdr0hMtKXRgeZazvXaFYCs7J7uTcWDHUhczab2qOCJLNDugoj8jFag1djb7wS9ehaRYBg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "gl-matrix": "^3.3.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@antv/vendor": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@antv/vendor/-/vendor-1.0.11.tgz",
+      "integrity": "sha512-LmhPEQ+aapk3barntaiIxJ5VHno/Tyab2JnfdcPzp5xONh/8VSfed4bo/9xKo5HcUAEydko38vYLfj6lJliLiw==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.2.1",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-dispatch": "^3.0.6",
+        "@types/d3-dsv": "^3.0.7",
+        "@types/d3-ease": "^3.0.2",
+        "@types/d3-fetch": "^3.0.7",
+        "@types/d3-force": "^3.0.10",
+        "@types/d3-format": "^3.0.4",
+        "@types/d3-geo": "^3.1.0",
+        "@types/d3-hierarchy": "^3.1.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-path": "^3.1.0",
+        "@types/d3-quadtree": "^3.0.6",
+        "@types/d3-random": "^3.0.3",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-scale-chromatic": "^3.1.0",
+        "@types/d3-shape": "^3.1.7",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-dispatch": "^3.0.1",
+        "d3-dsv": "^3.0.1",
+        "d3-ease": "^3.0.1",
+        "d3-fetch": "^3.0.1",
+        "d3-force": "^3.0.0",
+        "d3-force-3d": "^3.0.5",
+        "d3-format": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "d3-geo-projection": "^4.0.0",
+        "d3-hierarchy": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
+        "d3-quadtree": "^3.0.1",
+        "d3-random": "^3.0.1",
+        "d3-regression": "^1.3.10",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -906,11 +1305,146 @@
         "nanopop": "^2.1.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1423,8 +1957,26 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -1530,6 +2082,294 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-regression": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.18",
@@ -1646,6 +2486,12 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -1674,8 +2520,22 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/flru": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flru/-/flru-1.0.2.tgz",
+      "integrity": "sha512-kWyh8ADvHBFz6ua5xYOPnUroZTT/bwWfrCeL0Wj1dzG4/YOmOcfJ99W8dOVyyynJN35rZ9aCOtHChqQovV7yog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/frac": {
       "version": "1.1.2",
@@ -1751,6 +2611,18 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1777,6 +2649,21 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -2136,6 +3023,12 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/pdfast": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pdfast/-/pdfast-0.2.0.tgz",
+      "integrity": "sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2208,6 +3101,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -2222,6 +3124,29 @@
       },
       "bin": {
         "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
       }
     },
     "node_modules/registry-auth-token": {
@@ -2342,6 +3267,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "2.2.31",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
@@ -2438,6 +3376,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2542,6 +3489,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-path-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/svg-path-parser/-/svg-path-parser-1.1.0.tgz",
+      "integrity": "sha512-jGCUqcQyXpfe38R7RFfhrMyfXcBmpMNJI/B+4CE9/Unkh98UporAc461GTthv+TVDuZXsBx7/WiwJb1Oh4tt4A==",
+      "license": "MIT"
+    },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
@@ -2562,6 +3515,12 @@
       "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
       "integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "serve -s dist -l 8080"
   },
   "dependencies": {
+    "@ant-design/plots": "^2.6.5",
     "ant-design-vue": "^4.2.6",
     "dayjs": "^1.11.18",
     "mapbox-gl": "^2.15.0",

--- a/src/components/LspSummaryModal.vue
+++ b/src/components/LspSummaryModal.vue
@@ -1,0 +1,439 @@
+<template>
+  <a-modal
+    :open="isVisible"
+    title="LSP 统计"
+    :footer="null"
+    :destroy-on-close="false"
+    :mask-closable="true"
+    width="840px"
+    @cancel="handleClose"
+    @update:open="updateVisibility"
+  >
+    <div class="lsp-summary-modal">
+      <div v-if="isLoading" class="lsp-summary-modal__state">正在加载统计数据…</div>
+      <div v-else-if="error" class="lsp-summary-modal__state lsp-summary-modal__state--error">
+        {{ error }}
+      </div>
+      <div v-else-if="!lspSeries.length" class="lsp-summary-modal__state">暂无统计数据</div>
+      <div v-else class="lsp-summary-modal__chart">
+        <div class="lsp-summary-legend" role="list">
+          <div
+            v-for="legend in lspLegendItems"
+            :key="legend.lsp"
+            class="lsp-summary-legend__item"
+            role="listitem"
+          >
+            <span class="lsp-summary-legend__swatch" :style="{ backgroundColor: legend.color }"></span>
+            <span class="lsp-summary-legend__label">{{ legend.lsp }}</span>
+          </div>
+        </div>
+        <div class="lsp-summary-chart__container">
+          <svg
+            v-if="chartConfig"
+            class="lsp-summary-chart"
+            :viewBox="`0 0 ${chartConfig.width} ${chartConfig.height}`"
+            role="img"
+            aria-labelledby="lsp-chart-title"
+          >
+            <title id="lsp-chart-title">LSP 状态占比随时间变化折线图</title>
+            <desc>
+              展示各 LSP 在不同统计时间点的 status_not_empty / total_dn 百分比。
+            </desc>
+            <g class="lsp-chart__axes">
+              <line
+                :x1="chartConfig.padding.left"
+                :y1="chartConfig.height - chartConfig.padding.bottom"
+                :x2="chartConfig.width - chartConfig.padding.right"
+                :y2="chartConfig.height - chartConfig.padding.bottom"
+                class="lsp-chart__axis"
+              />
+              <line
+                :x1="chartConfig.padding.left"
+                :y1="chartConfig.padding.top"
+                :x2="chartConfig.padding.left"
+                :y2="chartConfig.height - chartConfig.padding.bottom"
+                class="lsp-chart__axis"
+              />
+              <g class="lsp-chart__y-ticks">
+                <template v-for="tick in chartConfig.yTicks" :key="tick.value">
+                  <line
+                    :x1="chartConfig.padding.left"
+                    :x2="chartConfig.width - chartConfig.padding.right"
+                    :y1="tick.y"
+                    :y2="tick.y"
+                    class="lsp-chart__grid"
+                  />
+                  <text
+                    :x="chartConfig.padding.left - 12"
+                    :y="tick.y + 4"
+                    text-anchor="end"
+                    class="lsp-chart__tick-label"
+                  >
+                    {{ tick.value }}%
+                  </text>
+                </template>
+              </g>
+              <g class="lsp-chart__x-ticks">
+                <template v-for="tick in chartConfig.xTicks" :key="tick.key">
+                  <text
+                    :x="tick.x"
+                    :y="chartConfig.height - chartConfig.padding.bottom + 36"
+                    text-anchor="middle"
+                    class="lsp-chart__tick-label"
+                  >
+                    {{ tick.label }}
+                  </text>
+                </template>
+              </g>
+            </g>
+            <g class="lsp-chart__series" v-for="series in chartConfig.series" :key="series.lsp">
+              <path
+                :d="series.path"
+                fill="none"
+                :stroke="series.color"
+                stroke-width="2"
+                stroke-linejoin="round"
+                stroke-linecap="round"
+              />
+              <g>
+                <circle
+                  v-for="point in series.points"
+                  :key="`${series.lsp}-${point.timeKey}`"
+                  :cx="point.x"
+                  :cy="point.y"
+                  r="5"
+                  :fill="series.color"
+                >
+                  <title>
+                    {{ series.lsp }}
+                    {{ '\n' }}统计时间：{{ point.recordedAtLabel }}
+                    {{ '\n' }}Status Not Empty：{{ point.statusNotEmpty }}
+                    {{ '\n' }}Total DN：{{ point.totalDn }}
+                    {{ '\n' }}占比：{{ point.percentage.toFixed(2) }}%
+                  </title>
+                </circle>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </a-modal>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { getApiBase } from '../utils/env';
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:open']);
+
+const isVisible = computed({
+  get: () => props.open,
+  set: (value) => {
+    emit('update:open', value);
+  },
+});
+
+const isLoading = ref(false);
+const error = ref('');
+const lspSummaryItems = ref([]);
+const hasFetched = ref(false);
+
+const colorPalette = [
+  '#5B8FF9',
+  '#5AD8A6',
+  '#F6BD16',
+  '#E86452',
+  '#6DC8EC',
+  '#9270CA',
+  '#FF9D4D',
+  '#269A99',
+  '#FF99C3',
+  '#B4EBBF',
+];
+
+const apiBase = getApiBase();
+
+const buildLspSummaryUrl = () => {
+  if (apiBase) {
+    return new URL('/api/dn/status-delivery/lsp-summary-records', apiBase).toString();
+  }
+  return '/api/dn/status-delivery/lsp-summary-records';
+};
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const processedSummary = computed(() => {
+  const items = Array.isArray(lspSummaryItems.value) ? lspSummaryItems.value : [];
+  return items
+    .map((item) => {
+      const totalDnRaw = Number(item.total_dn);
+      const statusNotEmptyRaw = Number(item.status_not_empty);
+      const totalDn = Number.isFinite(totalDnRaw) ? totalDnRaw : 0;
+      const statusNotEmpty = Number.isFinite(statusNotEmptyRaw) ? statusNotEmptyRaw : 0;
+      const recordedAt = item.recorded_at ? dayjs(item.recorded_at).tz('Asia/Jakarta') : null;
+      if (!recordedAt || !recordedAt.isValid()) return null;
+      const percentage = totalDn > 0 ? (statusNotEmpty / totalDn) * 100 : 0;
+      const timeKey = recordedAt.format('YYYY-MM-DD HH:mm');
+      return {
+        id: item.id,
+        lsp: item.lsp || '未命名 LSP',
+        totalDn,
+        statusNotEmpty,
+        recordedAt,
+        timeKey,
+        recordedAtLabel: recordedAt.format('YYYY-MM-DD HH:mm'),
+        label: recordedAt.format('DD MMM HH:mm'),
+        percentage,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
+});
+
+const uniqueLsps = computed(() => {
+  const set = new Set();
+  processedSummary.value.forEach((item) => {
+    set.add(item.lsp);
+  });
+  return Array.from(set);
+});
+
+const colorMap = computed(() => {
+  const map = new Map();
+  uniqueLsps.value.forEach((lsp, index) => {
+    map.set(lsp, colorPalette[index % colorPalette.length]);
+  });
+  return map;
+});
+
+const colorForLsp = (lsp) => colorMap.value.get(lsp) ?? '#888888';
+
+const timePoints = computed(() => {
+  const map = new Map();
+  processedSummary.value.forEach((item) => {
+    if (!map.has(item.timeKey)) {
+      map.set(item.timeKey, {
+        key: item.timeKey,
+        label: item.label,
+        recordedAt: item.recordedAt,
+      });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
+});
+
+const lspSeries = computed(() => {
+  const groups = new Map();
+  processedSummary.value.forEach((item) => {
+    if (!groups.has(item.lsp)) {
+      groups.set(item.lsp, []);
+    }
+    groups.get(item.lsp).push(item);
+  });
+
+  return Array.from(groups.entries()).map(([lsp, items]) => ({
+    lsp,
+    items: items.sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf()),
+  }));
+});
+
+const chartConfig = computed(() => {
+  if (!timePoints.value.length || !lspSeries.value.length) {
+    return null;
+  }
+
+  const width = 720;
+  const height = 360;
+  const padding = { top: 24, right: 32, bottom: 80, left: 72 };
+  const innerWidth = width - padding.left - padding.right;
+  const innerHeight = height - padding.top - padding.bottom;
+  const times = timePoints.value;
+  const timeIndexMap = new Map(times.map((time, index) => [time.key, index]));
+
+  const getX = (timeKey) => {
+    if (times.length === 1) {
+      return padding.left + innerWidth / 2;
+    }
+    const index = timeIndexMap.get(timeKey) ?? 0;
+    return padding.left + (index * innerWidth) / (times.length - 1);
+  };
+
+  const getY = (percentage) => {
+    const clamped = Math.max(0, Math.min(percentage, 100));
+    return padding.top + innerHeight * (1 - clamped / 100);
+  };
+
+  const series = lspSeries.value
+    .map(({ lsp, items }) => {
+      const points = items
+        .filter((item) => timeIndexMap.has(item.timeKey))
+        .map((item) => ({
+          x: getX(item.timeKey),
+          y: getY(item.percentage),
+          timeKey: item.timeKey,
+          percentage: item.percentage,
+          totalDn: item.totalDn,
+          statusNotEmpty: item.statusNotEmpty,
+          recordedAtLabel: item.recordedAtLabel,
+        }));
+
+      const path = points
+        .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`)
+        .join(' ');
+
+      return {
+        lsp,
+        color: colorForLsp(lsp),
+        points,
+        path,
+      };
+    })
+    .filter((seriesItem) => seriesItem.points.length);
+
+  if (!series.length) {
+    return null;
+  }
+
+  const yTicks = [0, 25, 50, 75, 100].map((value) => ({
+    value,
+    y: getY(value),
+  }));
+
+  const xTicks = times.map((time) => ({
+    key: time.key,
+    label: time.label,
+    x: getX(time.key),
+  }));
+
+  return { width, height, padding, series, yTicks, xTicks };
+});
+
+const lspLegendItems = computed(() =>
+  uniqueLsps.value.map((lsp) => ({
+    lsp,
+    color: colorForLsp(lsp),
+  }))
+);
+
+const fetchLspSummary = async () => {
+  try {
+    isLoading.value = true;
+    error.value = '';
+    const response = await fetch(buildLspSummaryUrl());
+    if (!response.ok) {
+      throw new Error(`统计数据获取失败（${response.status}）`);
+    }
+    const payload = await response.json();
+    if (!payload?.ok) {
+      throw new Error('统计数据返回异常');
+    }
+    lspSummaryItems.value = Array.isArray(payload.data) ? payload.data : [];
+    hasFetched.value = true;
+  } catch (err) {
+    console.error(err);
+    error.value = err?.message || '统计数据获取失败';
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open && !hasFetched.value) {
+      fetchLspSummary();
+    }
+  },
+  { immediate: false }
+);
+
+const handleClose = () => {
+  isVisible.value = false;
+};
+
+const updateVisibility = (value) => {
+  isVisible.value = value;
+};
+</script>
+
+<style scoped>
+.lsp-summary-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.lsp-summary-modal__state {
+  padding: 64px 24px;
+  text-align: center;
+  color: #475569;
+}
+
+.lsp-summary-modal__state--error {
+  color: #dc2626;
+}
+
+.lsp-summary-modal__chart {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.lsp-summary-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+}
+
+.lsp-summary-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #1e293b;
+}
+
+.lsp-summary-legend__swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.lsp-summary-chart__container {
+  overflow-x: auto;
+}
+
+.lsp-summary-chart {
+  width: 100%;
+  min-width: 720px;
+  height: auto;
+}
+
+.lsp-chart__axis {
+  stroke: #94a3b8;
+  stroke-width: 1;
+}
+
+.lsp-chart__grid {
+  stroke: #e2e8f0;
+  stroke-width: 1;
+}
+
+.lsp-chart__tick-label {
+  font-size: 12px;
+  fill: #475569;
+}
+</style>

--- a/src/components/LspSummaryModal.vue
+++ b/src/components/LspSummaryModal.vue
@@ -14,107 +14,15 @@
       <div v-else-if="error" class="lsp-summary-modal__state lsp-summary-modal__state--error">
         {{ error }}
       </div>
-      <div v-else-if="!lspSeries.length" class="lsp-summary-modal__state">暂无统计数据</div>
+      <div v-else-if="!chartData.length" class="lsp-summary-modal__state">暂无统计数据</div>
       <div v-else class="lsp-summary-modal__chart">
-        <div class="lsp-summary-legend" role="list">
-          <div
-            v-for="legend in lspLegendItems"
-            :key="legend.lsp"
-            class="lsp-summary-legend__item"
-            role="listitem"
-          >
-            <span class="lsp-summary-legend__swatch" :style="{ backgroundColor: legend.color }"></span>
-            <span class="lsp-summary-legend__label">{{ legend.lsp }}</span>
-          </div>
-        </div>
         <div class="lsp-summary-chart__container">
-          <svg
-            v-if="chartConfig"
+          <div
+            ref="chartContainer"
             class="lsp-summary-chart"
-            :viewBox="`0 0 ${chartConfig.width} ${chartConfig.height}`"
             role="img"
-            aria-labelledby="lsp-chart-title"
-          >
-            <title id="lsp-chart-title">LSP 状态占比随时间变化折线图</title>
-            <desc>
-              展示各 LSP 在不同统计时间点的 status_not_empty / total_dn 百分比。
-            </desc>
-            <g class="lsp-chart__axes">
-              <line
-                :x1="chartConfig.padding.left"
-                :y1="chartConfig.height - chartConfig.padding.bottom"
-                :x2="chartConfig.width - chartConfig.padding.right"
-                :y2="chartConfig.height - chartConfig.padding.bottom"
-                class="lsp-chart__axis"
-              />
-              <line
-                :x1="chartConfig.padding.left"
-                :y1="chartConfig.padding.top"
-                :x2="chartConfig.padding.left"
-                :y2="chartConfig.height - chartConfig.padding.bottom"
-                class="lsp-chart__axis"
-              />
-              <g class="lsp-chart__y-ticks">
-                <template v-for="tick in chartConfig.yTicks" :key="tick.value">
-                  <line
-                    :x1="chartConfig.padding.left"
-                    :x2="chartConfig.width - chartConfig.padding.right"
-                    :y1="tick.y"
-                    :y2="tick.y"
-                    class="lsp-chart__grid"
-                  />
-                  <text
-                    :x="chartConfig.padding.left - 12"
-                    :y="tick.y + 4"
-                    text-anchor="end"
-                    class="lsp-chart__tick-label"
-                  >
-                    {{ tick.value }}%
-                  </text>
-                </template>
-              </g>
-              <g class="lsp-chart__x-ticks">
-                <template v-for="tick in chartConfig.xTicks" :key="tick.key">
-                  <text
-                    :x="tick.x"
-                    :y="chartConfig.height - chartConfig.padding.bottom + 36"
-                    text-anchor="middle"
-                    class="lsp-chart__tick-label"
-                  >
-                    {{ tick.label }}
-                  </text>
-                </template>
-              </g>
-            </g>
-            <g class="lsp-chart__series" v-for="series in chartConfig.series" :key="series.lsp">
-              <path
-                :d="series.path"
-                fill="none"
-                :stroke="series.color"
-                stroke-width="2"
-                stroke-linejoin="round"
-                stroke-linecap="round"
-              />
-              <g>
-                <circle
-                  v-for="point in series.points"
-                  :key="`${series.lsp}-${point.timeKey}`"
-                  :cx="point.x"
-                  :cy="point.y"
-                  r="5"
-                  :fill="series.color"
-                >
-                  <title>
-                    {{ series.lsp }}
-                    {{ '\n' }}统计时间：{{ point.recordedAtLabel }}
-                    {{ '\n' }}Status Not Empty：{{ point.statusNotEmpty }}
-                    {{ '\n' }}Total DN：{{ point.totalDn }}
-                    {{ '\n' }}占比：{{ point.percentage.toFixed(2) }}%
-                  </title>
-                </circle>
-              </g>
-            </g>
-          </svg>
+            aria-label="LSP 状态占比随时间变化折线图"
+          ></div>
         </div>
       </div>
     </div>
@@ -122,7 +30,8 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { Line } from '@ant-design/plots/es/core/plots/line';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -148,6 +57,9 @@ const isLoading = ref(false);
 const error = ref('');
 const lspSummaryItems = ref([]);
 const hasFetched = ref(false);
+
+const chartContainer = ref(null);
+const chartInstance = ref(null);
 
 const colorPalette = [
   '#5B8FF9',
@@ -185,16 +97,15 @@ const processedSummary = computed(() => {
       const recordedAt = item.recorded_at ? dayjs(item.recorded_at).tz('Asia/Jakarta') : null;
       if (!recordedAt || !recordedAt.isValid()) return null;
       const percentage = totalDn > 0 ? (statusNotEmpty / totalDn) * 100 : 0;
-      const timeKey = recordedAt.format('YYYY-MM-DD HH:mm');
       return {
         id: item.id,
         lsp: item.lsp || '未命名 LSP',
         totalDn,
         statusNotEmpty,
         recordedAt,
-        timeKey,
-        recordedAtLabel: recordedAt.format('YYYY-MM-DD HH:mm'),
-        label: recordedAt.format('DD MMM HH:mm'),
+        timeKey: recordedAt.format('YYYY-MM-DD HH:mm'),
+        recordedAtLabel: recordedAt.format('DD MMM HH:mm'),
+        recordedAtTooltip: recordedAt.format('YYYY-MM-DD HH:mm'),
         percentage,
       };
     })
@@ -220,112 +131,141 @@ const colorMap = computed(() => {
 
 const colorForLsp = (lsp) => colorMap.value.get(lsp) ?? '#888888';
 
-const timePoints = computed(() => {
-  const map = new Map();
-  processedSummary.value.forEach((item) => {
-    if (!map.has(item.timeKey)) {
-      map.set(item.timeKey, {
-        key: item.timeKey,
-        label: item.label,
-        recordedAt: item.recordedAt,
-      });
-    }
-  });
-  return Array.from(map.values()).sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
-});
-
-const lspSeries = computed(() => {
-  const groups = new Map();
-  processedSummary.value.forEach((item) => {
-    if (!groups.has(item.lsp)) {
-      groups.set(item.lsp, []);
-    }
-    groups.get(item.lsp).push(item);
-  });
-
-  return Array.from(groups.entries()).map(([lsp, items]) => ({
-    lsp,
-    items: items.sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf()),
-  }));
-});
-
-const chartConfig = computed(() => {
-  if (!timePoints.value.length || !lspSeries.value.length) {
-    return null;
-  }
-
-  const width = 720;
-  const height = 360;
-  const padding = { top: 24, right: 32, bottom: 80, left: 72 };
-  const innerWidth = width - padding.left - padding.right;
-  const innerHeight = height - padding.top - padding.bottom;
-  const times = timePoints.value;
-  const timeIndexMap = new Map(times.map((time, index) => [time.key, index]));
-
-  const getX = (timeKey) => {
-    if (times.length === 1) {
-      return padding.left + innerWidth / 2;
-    }
-    const index = timeIndexMap.get(timeKey) ?? 0;
-    return padding.left + (index * innerWidth) / (times.length - 1);
-  };
-
-  const getY = (percentage) => {
-    const clamped = Math.max(0, Math.min(percentage, 100));
-    return padding.top + innerHeight * (1 - clamped / 100);
-  };
-
-  const series = lspSeries.value
-    .map(({ lsp, items }) => {
-      const points = items
-        .filter((item) => timeIndexMap.has(item.timeKey))
-        .map((item) => ({
-          x: getX(item.timeKey),
-          y: getY(item.percentage),
-          timeKey: item.timeKey,
-          percentage: item.percentage,
-          totalDn: item.totalDn,
-          statusNotEmpty: item.statusNotEmpty,
-          recordedAtLabel: item.recordedAtLabel,
-        }));
-
-      const path = points
-        .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`)
-        .join(' ');
-
-      return {
-        lsp,
-        color: colorForLsp(lsp),
-        points,
-        path,
-      };
-    })
-    .filter((seriesItem) => seriesItem.points.length);
-
-  if (!series.length) {
-    return null;
-  }
-
-  const yTicks = [0, 25, 50, 75, 100].map((value) => ({
-    value,
-    y: getY(value),
-  }));
-
-  const xTicks = times.map((time) => ({
-    key: time.key,
-    label: time.label,
-    x: getX(time.key),
-  }));
-
-  return { width, height, padding, series, yTicks, xTicks };
-});
-
-const lspLegendItems = computed(() =>
-  uniqueLsps.value.map((lsp) => ({
-    lsp,
-    color: colorForLsp(lsp),
+const chartData = computed(() =>
+  processedSummary.value.map((item) => ({
+    id: item.id,
+    lsp: item.lsp,
+    percentage: Number.isFinite(item.percentage) ? item.percentage : 0,
+    recordedAt: item.recordedAt.toDate(),
+    recordedAtLabel: item.recordedAtLabel,
+    recordedAtTooltip: item.recordedAtTooltip,
+    statusNotEmpty: item.statusNotEmpty,
+    totalDn: item.totalDn,
   }))
 );
+
+const chartOptions = computed(() => {
+  if (!chartData.value.length) {
+    return null;
+  }
+
+  return {
+    data: chartData.value,
+    xField: 'recordedAt',
+    yField: 'percentage',
+    seriesField: 'lsp',
+    colorField: 'lsp',
+    color: ({ lsp }) => colorForLsp(lsp),
+    scale: {
+      x: { type: 'time' },
+      y: { domain: [0, 100] },
+    },
+    axis: {
+      x: {
+        labelFormatter: (value) => dayjs(value).tz('Asia/Jakarta').format('DD MMM HH:mm'),
+      },
+      y: {
+        labelFormatter: (value) => `${value}%`,
+      },
+    },
+    legend: {
+      color: {
+        position: 'top',
+        title: false,
+      },
+    },
+    tooltip: {
+      title: (datum) => datum.recordedAtTooltip,
+      items: [
+        {
+          channel: 'y',
+          name: '占比',
+          valueFormatter: (value) => `${Number(value).toFixed(2)}%`,
+        },
+        {
+          name: 'Status Not Empty',
+          value: (datum) => `${datum.statusNotEmpty}`,
+        },
+        {
+          name: 'Total DN',
+          value: (datum) => `${datum.totalDn}`,
+        },
+      ],
+    },
+    line: {
+      style: {
+        lineWidth: 2,
+      },
+    },
+    point: {
+      shapeField: 'circle',
+      sizeField: 4,
+    },
+  };
+});
+
+const destroyChart = () => {
+  if (chartInstance.value) {
+    chartInstance.value.destroy();
+    chartInstance.value = null;
+  }
+};
+
+const renderChart = () => {
+  const options = chartOptions.value;
+  if (!props.open || !chartContainer.value || !options) {
+    if (!options) {
+      destroyChart();
+    }
+    return;
+  }
+
+  if (!chartInstance.value) {
+    chartInstance.value = new Line(chartContainer.value, options);
+  } else {
+    chartInstance.value.update(options);
+  }
+  chartInstance.value.render();
+};
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open && !hasFetched.value) {
+      fetchLspSummary();
+    }
+    if (!open) {
+      destroyChart();
+    }
+  },
+  { immediate: false }
+);
+
+watch(
+  () => chartOptions.value,
+  () => {
+    nextTick(() => {
+      if (props.open) {
+        renderChart();
+      }
+    });
+  }
+);
+
+watch(
+  () => chartContainer.value,
+  (el) => {
+    if (el && props.open) {
+      nextTick(() => {
+        renderChart();
+      });
+    }
+  }
+);
+
+onBeforeUnmount(() => {
+  destroyChart();
+});
 
 const fetchLspSummary = async () => {
   try {
@@ -348,16 +288,6 @@ const fetchLspSummary = async () => {
     isLoading.value = false;
   }
 };
-
-watch(
-  () => props.open,
-  (open) => {
-    if (open && !hasFetched.value) {
-      fetchLspSummary();
-    }
-  },
-  { immediate: false }
-);
 
 const handleClose = () => {
   isVisible.value = false;
@@ -388,52 +318,15 @@ const updateVisibility = (value) => {
 .lsp-summary-modal__chart {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-}
-
-.lsp-summary-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 24px;
-}
-
-.lsp-summary-legend__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: #1e293b;
-}
-
-.lsp-summary-legend__swatch {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
 }
 
 .lsp-summary-chart__container {
+  width: 100%;
   overflow-x: auto;
 }
 
 .lsp-summary-chart {
   width: 100%;
-  min-width: 720px;
-  height: auto;
-}
-
-.lsp-chart__axis {
-  stroke: #94a3b8;
-  stroke-width: 1;
-}
-
-.lsp-chart__grid {
-  stroke: #e2e8f0;
-  stroke-width: 1;
-}
-
-.lsp-chart__tick-label {
-  font-size: 12px;
-  fill: #475569;
+  min-height: 360px;
 }
 </style>

--- a/src/components/LspSummaryModal.vue
+++ b/src/components/LspSummaryModal.vue
@@ -5,7 +5,8 @@
     :footer="null"
     :destroy-on-close="false"
     :mask-closable="true"
-    width="840px"
+    width="90%"
+    wrap-class-name="lsp-summary-modal__dialog"
     @cancel="handleClose"
     @update:open="updateVisibility"
   >
@@ -328,5 +329,21 @@ const updateVisibility = (value) => {
 .lsp-summary-chart {
   width: 100%;
   min-height: 360px;
+}
+
+:deep(.lsp-summary-modal__dialog .ant-modal) {
+  width: 90% !important;
+  max-width: none;
+}
+
+:deep(.lsp-summary-modal__dialog .ant-modal-content) {
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+:deep(.lsp-summary-modal__dialog .ant-modal-body) {
+  flex: 1;
+  overflow: auto;
 }
 </style>

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -5,14 +5,14 @@
         <LanguageSwitcher v-model="currentLang" @change="changeLang" />
         <div class="auth-area">
           <span id="auth-role-tag" class="role-tag" data-i18n="auth.current"></span>
-          <button
-            v-if="showMapViewButton"
-            type="button"
-            class="btn ghost"
-            @click="openMapView"
-          >
-            地图视图
-          </button>
+          <template v-if="showMapViewButton">
+            <button type="button" class="btn ghost" @click="openLspSummaryModal">
+              LSP 统计
+            </button>
+            <button type="button" class="btn ghost" @click="openMapView">
+              地图视图
+            </button>
+          </template>
           <button class="btn ghost accent" id="btn-auth" data-i18n="auth.trigger">
             授权
           </button>
@@ -419,6 +419,8 @@
         </div>
       </div>
     </div>
+
+    <LspSummaryModal v-model:open="isLspSummaryModalVisible" />
   </div>
 </template>
 
@@ -437,6 +439,7 @@ import 'toastify-js/src/toastify.css';
 import { useBodyTheme } from '../composables/useBodyTheme';
 import 'dayjs/locale/zh-cn';
 import 'dayjs/locale/id';
+import LspSummaryModal from '../components/LspSummaryModal.vue';
 
 dayjs.extend(customParseFormat);
 
@@ -501,6 +504,11 @@ const openMapView = () => {
   if (typeof window !== 'undefined') {
     window.open(href, '_blank', 'noopener');
   }
+};
+
+const isLspSummaryModalVisible = ref(false);
+const openLspSummaryModal = () => {
+  isLspSummaryModalVisible.value = true;
 };
 
 const filterSelectOption = (input, option) => {

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -4,9 +4,6 @@
       <header class="sidebar-header">
         <div class="sidebar-header__top">
           <h1>DN 地图视图</h1>
-          <button type="button" class="btn ghost" @click="handleOpenLspSummary">
-            LSP 统计
-          </button>
         </div>
         <p class="sidebar-summary">
           共 <strong>{{ dnItems.length }}</strong> 条记录
@@ -53,113 +50,6 @@
       <div v-else ref="mapContainer" class="map-canvas"></div>
     </section>
 
-    <a-modal
-      v-model:open="isLspSummaryModalVisible"
-      title="LSP 统计"
-      :footer="null"
-      :destroy-on-close="false"
-      :mask-closable="true"
-      width="840px"
-      @cancel="handleCloseLspSummary"
-    >
-      <div class="lsp-summary-modal">
-        <div v-if="isLspSummaryLoading" class="lsp-summary-modal__state">正在加载统计数据…</div>
-        <div v-else-if="lspSummaryError" class="lsp-summary-modal__state lsp-summary-modal__state--error">
-          {{ lspSummaryError }}
-        </div>
-        <div v-else-if="!lspSeries.length" class="lsp-summary-modal__state">暂无统计数据</div>
-        <div v-else class="lsp-summary-modal__chart">
-          <div class="lsp-summary-legend" role="list">
-            <div v-for="legend in lspLegendItems" :key="legend.lsp" class="lsp-summary-legend__item" role="listitem">
-              <span class="lsp-summary-legend__swatch" :style="{ backgroundColor: legend.color }"></span>
-              <span class="lsp-summary-legend__label">{{ legend.lsp }}</span>
-            </div>
-          </div>
-          <div class="lsp-summary-chart__container">
-            <svg
-              v-if="chartConfig"
-              class="lsp-summary-chart"
-              :viewBox="`0 0 ${chartConfig.width} ${chartConfig.height}`"
-              role="img"
-              aria-labelledby="lsp-chart-title"
-            >
-              <title id="lsp-chart-title">LSP 状态占比随时间变化折线图</title>
-              <desc>
-                展示各 LSP 在不同统计时间点的 status_not_empty / total_dn 百分比。
-              </desc>
-              <g class="lsp-chart__axes">
-                <line
-                  :x1="chartConfig.padding.left"
-                  :y1="chartConfig.height - chartConfig.padding.bottom"
-                  :x2="chartConfig.width - chartConfig.padding.right"
-                  :y2="chartConfig.height - chartConfig.padding.bottom"
-                  class="lsp-chart__axis"
-                />
-                <line
-                  :x1="chartConfig.padding.left"
-                  :y1="chartConfig.padding.top"
-                  :x2="chartConfig.padding.left"
-                  :y2="chartConfig.height - chartConfig.padding.bottom"
-                  class="lsp-chart__axis"
-                />
-                <g class="lsp-chart__y-ticks">
-                  <template v-for="tick in chartConfig.yTicks" :key="tick.value">
-                    <line
-                      :x1="chartConfig.padding.left"
-                      :x2="chartConfig.width - chartConfig.padding.right"
-                      :y1="tick.y"
-                      :y2="tick.y"
-                      class="lsp-chart__grid"
-                    />
-                    <text
-                      :x="chartConfig.padding.left - 12"
-                      :y="tick.y + 4"
-                      text-anchor="end"
-                      class="lsp-chart__tick-label"
-                    >
-                      {{ tick.value }}%
-                    </text>
-                  </template>
-                </g>
-                <g class="lsp-chart__x-ticks">
-                  <template v-for="tick in chartConfig.xTicks" :key="tick.key">
-                    <text
-                      :x="tick.x"
-                      :y="chartConfig.height - chartConfig.padding.bottom + 36"
-                      text-anchor="middle"
-                      class="lsp-chart__tick-label"
-                    >
-                      {{ tick.label }}
-                    </text>
-                  </template>
-                </g>
-              </g>
-              <g class="lsp-chart__series" v-for="series in chartConfig.series" :key="series.lsp">
-                <path :d="series.path" fill="none" :stroke="series.color" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-                <g>
-                  <circle
-                    v-for="point in series.points"
-                    :key="`${series.lsp}-${point.timeKey}`"
-                    :cx="point.x"
-                    :cy="point.y"
-                    r="5"
-                    :fill="series.color"
-                  >
-                    <title>
-                      {{ series.lsp }}
-                      {{ '\n' }}统计时间：{{ point.recordedAtLabel }}
-                      {{ '\n' }}Status Not Empty：{{ point.statusNotEmpty }}
-                      {{ '\n' }}Total DN：{{ point.totalDn }}
-                      {{ '\n' }}占比：{{ point.percentage.toFixed(2) }}%
-                    </title>
-                  </circle>
-                </g>
-              </g>
-            </svg>
-          </div>
-        </div>
-      </div>
-    </a-modal>
   </div>
 </template>
 
@@ -168,12 +58,6 @@ import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vu
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { getApiBase, getMapboxAccessToken } from '../utils/env';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 const mapboxToken = getMapboxAccessToken();
 
@@ -189,30 +73,11 @@ const activeRoutes = [];
 let pendingMarkerData = null;
 let currentRouteGeneration = 0;
 
-const isLspSummaryModalVisible = ref(false);
-const isLspSummaryLoading = ref(false);
-const lspSummaryError = ref('');
-const lspSummaryItems = ref([]);
-const hasFetchedLspSummary = ref(false);
-
 const ORIGIN_COORDINATES = [107.08, -6.29];
 const ROUTE_SOURCE_PREFIX = 'dn-route-source-';
 const ROUTE_LAYER_PREFIX = 'dn-route-layer-';
 
 const apiBase = getApiBase();
-
-const colorPalette = [
-  '#5B8FF9',
-  '#5AD8A6',
-  '#F6BD16',
-  '#E86452',
-  '#6DC8EC',
-  '#9270CA',
-  '#FF9D4D',
-  '#269A99',
-  '#FF99C3',
-  '#B4EBBF',
-];
 
 const buildRequestUrl = (page) => {
   const params = new URLSearchParams({
@@ -228,13 +93,6 @@ const buildRequestUrl = (page) => {
   }
 
   return `/api/dn/list/search?${params.toString()}`;
-};
-
-const buildLspSummaryUrl = () => {
-  if (apiBase) {
-    return new URL('/api/dn/status-delivery/lsp-summary-records', apiBase).toString();
-  }
-  return '/api/dn/status-delivery/lsp-summary-records';
 };
 
 const normalizeNumber = (value) => {
@@ -300,189 +158,6 @@ const mapPoints = computed(() => {
     })
     .filter(Boolean);
 });
-
-const processedLspSummary = computed(() => {
-  const items = Array.isArray(lspSummaryItems.value) ? lspSummaryItems.value : [];
-  return items
-    .map((item) => {
-      const totalDnRaw = Number(item.total_dn);
-      const statusNotEmptyRaw = Number(item.status_not_empty);
-      const totalDn = Number.isFinite(totalDnRaw) ? totalDnRaw : 0;
-      const statusNotEmpty = Number.isFinite(statusNotEmptyRaw) ? statusNotEmptyRaw : 0;
-      const recordedAt = item.recorded_at ? dayjs(item.recorded_at).tz('Asia/Jakarta') : null;
-      if (!recordedAt || !recordedAt.isValid()) return null;
-      const percentage = totalDn > 0 ? (statusNotEmpty / totalDn) * 100 : 0;
-      const timeKey = recordedAt.format('YYYY-MM-DD HH:mm');
-      return {
-        id: item.id,
-        lsp: item.lsp || '未命名 LSP',
-        totalDn,
-        statusNotEmpty,
-        recordedAt,
-        timeKey,
-        recordedAtLabel: recordedAt.format('YYYY-MM-DD HH:mm'),
-        label: recordedAt.format('DD MMM HH:mm'),
-        percentage,
-      };
-    })
-    .filter(Boolean)
-    .sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
-});
-
-const uniqueLsps = computed(() => {
-  const set = new Set();
-  processedLspSummary.value.forEach((item) => {
-    set.add(item.lsp);
-  });
-  return Array.from(set);
-});
-
-const colorMap = computed(() => {
-  const map = new Map();
-  uniqueLsps.value.forEach((lsp, index) => {
-    map.set(lsp, colorPalette[index % colorPalette.length]);
-  });
-  return map;
-});
-
-const colorForLsp = (lsp) => colorMap.value.get(lsp) ?? '#888888';
-
-const timePoints = computed(() => {
-  const map = new Map();
-  processedLspSummary.value.forEach((item) => {
-    if (!map.has(item.timeKey)) {
-      map.set(item.timeKey, {
-        key: item.timeKey,
-        label: item.label,
-        recordedAt: item.recordedAt,
-      });
-    }
-  });
-  return Array.from(map.values()).sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
-});
-
-const lspSeries = computed(() => {
-  const groups = new Map();
-  processedLspSummary.value.forEach((item) => {
-    if (!groups.has(item.lsp)) {
-      groups.set(item.lsp, []);
-    }
-    groups.get(item.lsp).push(item);
-  });
-
-  return Array.from(groups.entries()).map(([lsp, items]) => ({
-    lsp,
-    items: items.sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf()),
-  }));
-});
-
-const chartConfig = computed(() => {
-  if (!timePoints.value.length || !lspSeries.value.length) {
-    return null;
-  }
-
-  const width = 720;
-  const height = 360;
-  const padding = { top: 24, right: 32, bottom: 80, left: 72 };
-  const innerWidth = width - padding.left - padding.right;
-  const innerHeight = height - padding.top - padding.bottom;
-  const times = timePoints.value;
-  const timeIndexMap = new Map(times.map((time, index) => [time.key, index]));
-
-  const getX = (timeKey) => {
-    if (times.length === 1) {
-      return padding.left + innerWidth / 2;
-    }
-    const index = timeIndexMap.get(timeKey) ?? 0;
-    return padding.left + (index * innerWidth) / (times.length - 1);
-  };
-
-  const getY = (percentage) => {
-    const clamped = Math.max(0, Math.min(percentage, 100));
-    return padding.top + innerHeight * (1 - clamped / 100);
-  };
-
-  const series = lspSeries.value.map(({ lsp, items }) => {
-    const points = items
-      .filter((item) => timeIndexMap.has(item.timeKey))
-      .map((item) => ({
-        x: getX(item.timeKey),
-        y: getY(item.percentage),
-        timeKey: item.timeKey,
-        percentage: item.percentage,
-        totalDn: item.totalDn,
-        statusNotEmpty: item.statusNotEmpty,
-        recordedAtLabel: item.recordedAtLabel,
-      }));
-
-    const path = points
-      .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`)
-      .join(' ');
-
-    return {
-      lsp,
-      color: colorForLsp(lsp),
-      points,
-      path,
-    };
-  }).filter((seriesItem) => seriesItem.points.length);
-
-  if (!series.length) {
-    return null;
-  }
-
-  const yTicks = [0, 25, 50, 75, 100].map((value) => ({
-    value,
-    y: getY(value),
-  }));
-
-  const xTicks = times.map((time) => ({
-    key: time.key,
-    label: time.label,
-    x: getX(time.key),
-  }));
-
-  return { width, height, padding, series, yTicks, xTicks };
-});
-
-const lspLegendItems = computed(() =>
-  uniqueLsps.value.map((lsp) => ({
-    lsp,
-    color: colorForLsp(lsp),
-  }))
-);
-
-const handleOpenLspSummary = async () => {
-  isLspSummaryModalVisible.value = true;
-  if (hasFetchedLspSummary.value) return;
-  await fetchLspSummary();
-};
-
-const handleCloseLspSummary = () => {
-  isLspSummaryModalVisible.value = false;
-};
-
-const fetchLspSummary = async () => {
-  try {
-    isLspSummaryLoading.value = true;
-    lspSummaryError.value = '';
-    const response = await fetch(buildLspSummaryUrl());
-    if (!response.ok) {
-      throw new Error(`统计数据获取失败（${response.status}）`);
-    }
-    const payload = await response.json();
-    if (!payload?.ok) {
-      throw new Error('统计数据返回异常');
-    }
-    lspSummaryItems.value = Array.isArray(payload.data) ? payload.data : [];
-    hasFetchedLspSummary.value = true;
-  } catch (err) {
-    console.error(err);
-    lspSummaryError.value = err?.message || '统计数据获取失败';
-  } finally {
-    isLspSummaryLoading.value = false;
-  }
-};
 
 const clearMarkers = () => {
   while (activeMarkers.length) {
@@ -949,75 +624,6 @@ onBeforeUnmount(() => {
 .marker-popup strong {
   display: block;
   margin-bottom: 6px;
-}
-
-.lsp-summary-modal {
-  min-height: 280px;
-}
-
-.lsp-summary-modal__state {
-  padding: 32px 16px;
-  text-align: center;
-  color: #475569;
-}
-
-.lsp-summary-modal__state--error {
-  color: #b91c1c;
-}
-
-.lsp-summary-modal__chart {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.lsp-summary-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 16px;
-}
-
-.lsp-summary-legend__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: #0f172a;
-}
-
-.lsp-summary-legend__swatch {
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: #94a3b8;
-}
-
-.lsp-summary-chart__container {
-  overflow-x: auto;
-  padding-bottom: 8px;
-}
-
-.lsp-summary-chart {
-  width: 100%;
-  height: auto;
-  min-width: 680px;
-  color: #0f172a;
-}
-
-.lsp-chart__axis {
-  stroke: #94a3b8;
-  stroke-width: 1;
-}
-
-.lsp-chart__grid {
-  stroke: rgba(148, 163, 184, 0.35);
-  stroke-width: 1;
-  stroke-dasharray: 4 4;
-}
-
-.lsp-chart__tick-label {
-  fill: #475569;
-  font-size: 12px;
 }
 
 @media (max-width: 960px) {

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -2,7 +2,12 @@
   <div class="map-view">
     <aside class="map-view__sidebar">
       <header class="sidebar-header">
-        <h1>DN 地图视图</h1>
+        <div class="sidebar-header__top">
+          <h1>DN 地图视图</h1>
+          <button type="button" class="btn ghost" @click="handleOpenLspSummary">
+            LSP 统计
+          </button>
+        </div>
         <p class="sidebar-summary">
           共 <strong>{{ dnItems.length }}</strong> 条记录
         </p>
@@ -47,6 +52,114 @@
       </div>
       <div v-else ref="mapContainer" class="map-canvas"></div>
     </section>
+
+    <a-modal
+      v-model:open="isLspSummaryModalVisible"
+      title="LSP 统计"
+      :footer="null"
+      :destroy-on-close="false"
+      :mask-closable="true"
+      width="840px"
+      @cancel="handleCloseLspSummary"
+    >
+      <div class="lsp-summary-modal">
+        <div v-if="isLspSummaryLoading" class="lsp-summary-modal__state">正在加载统计数据…</div>
+        <div v-else-if="lspSummaryError" class="lsp-summary-modal__state lsp-summary-modal__state--error">
+          {{ lspSummaryError }}
+        </div>
+        <div v-else-if="!lspSeries.length" class="lsp-summary-modal__state">暂无统计数据</div>
+        <div v-else class="lsp-summary-modal__chart">
+          <div class="lsp-summary-legend" role="list">
+            <div v-for="legend in lspLegendItems" :key="legend.lsp" class="lsp-summary-legend__item" role="listitem">
+              <span class="lsp-summary-legend__swatch" :style="{ backgroundColor: legend.color }"></span>
+              <span class="lsp-summary-legend__label">{{ legend.lsp }}</span>
+            </div>
+          </div>
+          <div class="lsp-summary-chart__container">
+            <svg
+              v-if="chartConfig"
+              class="lsp-summary-chart"
+              :viewBox="`0 0 ${chartConfig.width} ${chartConfig.height}`"
+              role="img"
+              aria-labelledby="lsp-chart-title"
+            >
+              <title id="lsp-chart-title">LSP 状态占比随时间变化折线图</title>
+              <desc>
+                展示各 LSP 在不同统计时间点的 status_not_empty / total_dn 百分比。
+              </desc>
+              <g class="lsp-chart__axes">
+                <line
+                  :x1="chartConfig.padding.left"
+                  :y1="chartConfig.height - chartConfig.padding.bottom"
+                  :x2="chartConfig.width - chartConfig.padding.right"
+                  :y2="chartConfig.height - chartConfig.padding.bottom"
+                  class="lsp-chart__axis"
+                />
+                <line
+                  :x1="chartConfig.padding.left"
+                  :y1="chartConfig.padding.top"
+                  :x2="chartConfig.padding.left"
+                  :y2="chartConfig.height - chartConfig.padding.bottom"
+                  class="lsp-chart__axis"
+                />
+                <g class="lsp-chart__y-ticks">
+                  <template v-for="tick in chartConfig.yTicks" :key="tick.value">
+                    <line
+                      :x1="chartConfig.padding.left"
+                      :x2="chartConfig.width - chartConfig.padding.right"
+                      :y1="tick.y"
+                      :y2="tick.y"
+                      class="lsp-chart__grid"
+                    />
+                    <text
+                      :x="chartConfig.padding.left - 12"
+                      :y="tick.y + 4"
+                      text-anchor="end"
+                      class="lsp-chart__tick-label"
+                    >
+                      {{ tick.value }}%
+                    </text>
+                  </template>
+                </g>
+                <g class="lsp-chart__x-ticks">
+                  <template v-for="tick in chartConfig.xTicks" :key="tick.key">
+                    <text
+                      :x="tick.x"
+                      :y="chartConfig.height - chartConfig.padding.bottom + 36"
+                      text-anchor="middle"
+                      class="lsp-chart__tick-label"
+                    >
+                      {{ tick.label }}
+                    </text>
+                  </template>
+                </g>
+              </g>
+              <g class="lsp-chart__series" v-for="series in chartConfig.series" :key="series.lsp">
+                <path :d="series.path" fill="none" :stroke="series.color" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+                <g>
+                  <circle
+                    v-for="point in series.points"
+                    :key="`${series.lsp}-${point.timeKey}`"
+                    :cx="point.x"
+                    :cy="point.y"
+                    r="5"
+                    :fill="series.color"
+                  >
+                    <title>
+                      {{ series.lsp }}
+                      {{ '\n' }}统计时间：{{ point.recordedAtLabel }}
+                      {{ '\n' }}Status Not Empty：{{ point.statusNotEmpty }}
+                      {{ '\n' }}Total DN：{{ point.totalDn }}
+                      {{ '\n' }}占比：{{ point.percentage.toFixed(2) }}%
+                    </title>
+                  </circle>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </a-modal>
   </div>
 </template>
 
@@ -55,6 +168,12 @@ import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vu
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { getApiBase, getMapboxAccessToken } from '../utils/env';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const mapboxToken = getMapboxAccessToken();
 
@@ -70,11 +189,30 @@ const activeRoutes = [];
 let pendingMarkerData = null;
 let currentRouteGeneration = 0;
 
+const isLspSummaryModalVisible = ref(false);
+const isLspSummaryLoading = ref(false);
+const lspSummaryError = ref('');
+const lspSummaryItems = ref([]);
+const hasFetchedLspSummary = ref(false);
+
 const ORIGIN_COORDINATES = [107.08, -6.29];
 const ROUTE_SOURCE_PREFIX = 'dn-route-source-';
 const ROUTE_LAYER_PREFIX = 'dn-route-layer-';
 
 const apiBase = getApiBase();
+
+const colorPalette = [
+  '#5B8FF9',
+  '#5AD8A6',
+  '#F6BD16',
+  '#E86452',
+  '#6DC8EC',
+  '#9270CA',
+  '#FF9D4D',
+  '#269A99',
+  '#FF99C3',
+  '#B4EBBF',
+];
 
 const buildRequestUrl = (page) => {
   const params = new URLSearchParams({
@@ -90,6 +228,13 @@ const buildRequestUrl = (page) => {
   }
 
   return `/api/dn/list/search?${params.toString()}`;
+};
+
+const buildLspSummaryUrl = () => {
+  if (apiBase) {
+    return new URL('/api/dn/status-delivery/lsp-summary-records', apiBase).toString();
+  }
+  return '/api/dn/status-delivery/lsp-summary-records';
 };
 
 const normalizeNumber = (value) => {
@@ -155,6 +300,189 @@ const mapPoints = computed(() => {
     })
     .filter(Boolean);
 });
+
+const processedLspSummary = computed(() => {
+  const items = Array.isArray(lspSummaryItems.value) ? lspSummaryItems.value : [];
+  return items
+    .map((item) => {
+      const totalDnRaw = Number(item.total_dn);
+      const statusNotEmptyRaw = Number(item.status_not_empty);
+      const totalDn = Number.isFinite(totalDnRaw) ? totalDnRaw : 0;
+      const statusNotEmpty = Number.isFinite(statusNotEmptyRaw) ? statusNotEmptyRaw : 0;
+      const recordedAt = item.recorded_at ? dayjs(item.recorded_at).tz('Asia/Jakarta') : null;
+      if (!recordedAt || !recordedAt.isValid()) return null;
+      const percentage = totalDn > 0 ? (statusNotEmpty / totalDn) * 100 : 0;
+      const timeKey = recordedAt.format('YYYY-MM-DD HH:mm');
+      return {
+        id: item.id,
+        lsp: item.lsp || '未命名 LSP',
+        totalDn,
+        statusNotEmpty,
+        recordedAt,
+        timeKey,
+        recordedAtLabel: recordedAt.format('YYYY-MM-DD HH:mm'),
+        label: recordedAt.format('DD MMM HH:mm'),
+        percentage,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
+});
+
+const uniqueLsps = computed(() => {
+  const set = new Set();
+  processedLspSummary.value.forEach((item) => {
+    set.add(item.lsp);
+  });
+  return Array.from(set);
+});
+
+const colorMap = computed(() => {
+  const map = new Map();
+  uniqueLsps.value.forEach((lsp, index) => {
+    map.set(lsp, colorPalette[index % colorPalette.length]);
+  });
+  return map;
+});
+
+const colorForLsp = (lsp) => colorMap.value.get(lsp) ?? '#888888';
+
+const timePoints = computed(() => {
+  const map = new Map();
+  processedLspSummary.value.forEach((item) => {
+    if (!map.has(item.timeKey)) {
+      map.set(item.timeKey, {
+        key: item.timeKey,
+        label: item.label,
+        recordedAt: item.recordedAt,
+      });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf());
+});
+
+const lspSeries = computed(() => {
+  const groups = new Map();
+  processedLspSummary.value.forEach((item) => {
+    if (!groups.has(item.lsp)) {
+      groups.set(item.lsp, []);
+    }
+    groups.get(item.lsp).push(item);
+  });
+
+  return Array.from(groups.entries()).map(([lsp, items]) => ({
+    lsp,
+    items: items.sort((a, b) => a.recordedAt.valueOf() - b.recordedAt.valueOf()),
+  }));
+});
+
+const chartConfig = computed(() => {
+  if (!timePoints.value.length || !lspSeries.value.length) {
+    return null;
+  }
+
+  const width = 720;
+  const height = 360;
+  const padding = { top: 24, right: 32, bottom: 80, left: 72 };
+  const innerWidth = width - padding.left - padding.right;
+  const innerHeight = height - padding.top - padding.bottom;
+  const times = timePoints.value;
+  const timeIndexMap = new Map(times.map((time, index) => [time.key, index]));
+
+  const getX = (timeKey) => {
+    if (times.length === 1) {
+      return padding.left + innerWidth / 2;
+    }
+    const index = timeIndexMap.get(timeKey) ?? 0;
+    return padding.left + (index * innerWidth) / (times.length - 1);
+  };
+
+  const getY = (percentage) => {
+    const clamped = Math.max(0, Math.min(percentage, 100));
+    return padding.top + innerHeight * (1 - clamped / 100);
+  };
+
+  const series = lspSeries.value.map(({ lsp, items }) => {
+    const points = items
+      .filter((item) => timeIndexMap.has(item.timeKey))
+      .map((item) => ({
+        x: getX(item.timeKey),
+        y: getY(item.percentage),
+        timeKey: item.timeKey,
+        percentage: item.percentage,
+        totalDn: item.totalDn,
+        statusNotEmpty: item.statusNotEmpty,
+        recordedAtLabel: item.recordedAtLabel,
+      }));
+
+    const path = points
+      .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`)
+      .join(' ');
+
+    return {
+      lsp,
+      color: colorForLsp(lsp),
+      points,
+      path,
+    };
+  }).filter((seriesItem) => seriesItem.points.length);
+
+  if (!series.length) {
+    return null;
+  }
+
+  const yTicks = [0, 25, 50, 75, 100].map((value) => ({
+    value,
+    y: getY(value),
+  }));
+
+  const xTicks = times.map((time) => ({
+    key: time.key,
+    label: time.label,
+    x: getX(time.key),
+  }));
+
+  return { width, height, padding, series, yTicks, xTicks };
+});
+
+const lspLegendItems = computed(() =>
+  uniqueLsps.value.map((lsp) => ({
+    lsp,
+    color: colorForLsp(lsp),
+  }))
+);
+
+const handleOpenLspSummary = async () => {
+  isLspSummaryModalVisible.value = true;
+  if (hasFetchedLspSummary.value) return;
+  await fetchLspSummary();
+};
+
+const handleCloseLspSummary = () => {
+  isLspSummaryModalVisible.value = false;
+};
+
+const fetchLspSummary = async () => {
+  try {
+    isLspSummaryLoading.value = true;
+    lspSummaryError.value = '';
+    const response = await fetch(buildLspSummaryUrl());
+    if (!response.ok) {
+      throw new Error(`统计数据获取失败（${response.status}）`);
+    }
+    const payload = await response.json();
+    if (!payload?.ok) {
+      throw new Error('统计数据返回异常');
+    }
+    lspSummaryItems.value = Array.isArray(payload.data) ? payload.data : [];
+    hasFetchedLspSummary.value = true;
+  } catch (err) {
+    console.error(err);
+    lspSummaryError.value = err?.message || '统计数据获取失败';
+  } finally {
+    isLspSummaryLoading.value = false;
+  }
+};
 
 const clearMarkers = () => {
   while (activeMarkers.length) {
@@ -463,14 +791,25 @@ onBeforeUnmount(() => {
   border-bottom: 1px solid #e2e8f0;
 }
 
+.sidebar-header__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .sidebar-header h1 {
-  margin: 0 0 8px;
+  margin: 0;
   font-size: 22px;
   font-weight: 600;
 }
 
+.sidebar-header__top .btn {
+  white-space: nowrap;
+}
+
 .sidebar-summary {
-  margin: 0;
+  margin: 12px 0 0;
   color: #64748b;
   font-size: 14px;
 }
@@ -610,6 +949,75 @@ onBeforeUnmount(() => {
 .marker-popup strong {
   display: block;
   margin-bottom: 6px;
+}
+
+.lsp-summary-modal {
+  min-height: 280px;
+}
+
+.lsp-summary-modal__state {
+  padding: 32px 16px;
+  text-align: center;
+  color: #475569;
+}
+
+.lsp-summary-modal__state--error {
+  color: #b91c1c;
+}
+
+.lsp-summary-modal__chart {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.lsp-summary-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+}
+
+.lsp-summary-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.lsp-summary-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #94a3b8;
+}
+
+.lsp-summary-chart__container {
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.lsp-summary-chart {
+  width: 100%;
+  height: auto;
+  min-width: 680px;
+  color: #0f172a;
+}
+
+.lsp-chart__axis {
+  stroke: #94a3b8;
+  stroke-width: 1;
+}
+
+.lsp-chart__grid {
+  stroke: rgba(148, 163, 184, 0.35);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+}
+
+.lsp-chart__tick-label {
+  fill: #475569;
+  font-size: 12px;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add an LSP statistics button to the map sidebar that opens a modal with a multi-series line chart
- fetch LSP delivery summaries on demand and compute time-series percentages using Jakarta timezone
- style the modal with legend, SVG axes, tooltips, and responsive layout for the chart

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8e47f6b883209fb467fbc2d978c3