### PR TITLE
Update status mismatch check for in-transit deliveries

### DIFF
--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -604,7 +604,14 @@ export function setupAdminPage(
     const podStatus = DN_SCAN_STATUS_VALUES.POD || 'POD';
 
     if (delivery === STATUS_VALUES.ON_THE_WAY) {
-      return status === arrivedStatus || status === podStatus;
+      const allowedTransportStatuses = [
+        DN_SCAN_STATUS_VALUES.TRANSPORTING_FROM_WH,
+        DN_SCAN_STATUS_VALUES.TRANSPORTING_FROM_XD_PM,
+      ]
+        .map((value) => normalizeStatusValue(value))
+        .filter(Boolean);
+      const isAllowedTransportStatus = allowedTransportStatuses.includes(status);
+      return !isAllowedTransportStatus;
     }
     if (delivery === STATUS_VALUES.ON_SITE) {
       return status !== arrivedStatus && status !== podStatus;


### PR DESCRIPTION
## Summary
- flag status mismatches for "On the way" deliveries unless the DN status indicates transport from WH or XD/PM
- reuse normalized values for transport statuses when validating mismatch states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e092d3ac30832089e4f4f9b6549295