### PR TITLE
Fix admin mobile layout for check-in actions

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -11,31 +11,36 @@
 }
 @media (max-width: 960px) {
     .admin-page td.summary-checkin-cell .checkin-cell {
-        flex-direction: column;
-        gap: 6px;
-        align-items: flex-start;
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
     }
     .admin-page td.summary-checkin-cell .checkin-cell .icon-link,
     .admin-page td.summary-checkin-cell .checkin-cell .map-link {
         align-items: center;
-        justify-content: flex-start;
+        justify-content: center;
         display: inline-flex;
         min-height: 24px;
     }
 }
 @media (max-width: 1100px) {
-    /* 打卡列竖向展示 */
-            .admin-page td.summary-checkin-cell .checkin-cell {
-                flex-direction: column;
-                gap: 2px;
-                align-items: center;
+    /* 打卡列保持同一行显示 */
+    .admin-page td.summary-checkin-cell .checkin-cell {
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
     }
-    /* 操作列竖向展示 */
-            .admin-page table th:last-child .actions,
-            .admin-page table td:last-child .actions {
-                flex-direction: column;
-                align-items: center;
-                gap: 1px;
+    /* 操作列按钮横向对齐 */
+    .admin-page table th:last-child .actions,
+    .admin-page table td:last-child .actions {
+        flex-direction: row;
+        align-items: center;
+        gap: 8px;
+        justify-content: flex-start;
     }
         .admin-page table th:last-child .actions .icon-btn,
         .admin-page table th:last-child .actions .icon-link,


### PR DESCRIPTION
## Summary
- keep the check-in photo and location controls on a single row for narrow admin screens
- align the edit and delete buttons horizontally in the admin actions column on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5a886256483208710c66efb4649d6