### PR TITLE
Prevent background scrolling behind admin modals

### DIFF
--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -805,6 +805,10 @@ body.admin-theme {
     flex: 1 1 220px;
     max-width: 250px
     }
+html.admin-scroll-locked,
+body.admin-scroll-locked {
+    overflow: hidden
+    }
 .admin-page .filters-grid .field input, .admin-page .filters-grid .field select {
     width: 100%;
     background-color: var(--ant-surface);

--- a/src/views/admin/authHandler.js
+++ b/src/views/admin/authHandler.js
@@ -5,6 +5,7 @@
 
 import { ROLE_LIST } from '../../config.js';
 import { ROLE_MAP, AUTH_STORAGE_KEY } from './constants.js';
+import { lockBodyScroll, unlockBodyScroll } from './utils.js';
 
 /**
  * 清理用户信息对象
@@ -188,7 +189,11 @@ export function createAuthHandler(options) {
    */
   function openAuthModal() {
     if (!authModal) return;
+    const wasVisible = authModal.style.display === 'flex';
     authModal.style.display = 'flex';
+    if (!wasVisible) {
+      lockBodyScroll();
+    }
     if (authMsg) authMsg.textContent = '';
     if (authInput) {
       authInput.value = '';
@@ -206,7 +211,13 @@ export function createAuthHandler(options) {
    * 关闭授权登录模态框
    */
   function closeAuthModal() {
-    if (authModal) authModal.style.display = 'none';
+    if (authModal) {
+      const wasVisible = authModal.style.display === 'flex';
+      authModal.style.display = 'none';
+      if (wasVisible) {
+        unlockBodyScroll();
+      }
+    }
   }
 
   /**

--- a/src/views/admin/dnEntry.js
+++ b/src/views/admin/dnEntry.js
@@ -1,4 +1,4 @@
-import { escapeHtml } from './utils.js';
+import { escapeHtml, lockBodyScroll, unlockBodyScroll } from './utils.js';
 import { TRANSPORT_MANAGER_ROLE_KEY } from './constants.js';
 import { normalizeDnSoft, DN_VALID_RE } from '../../utils/dn.js';
 
@@ -157,7 +157,11 @@ export function createDnEntryManager({
       );
       return;
     }
+    const wasVisible = dnModal.style.display === 'flex';
     dnModal.style.display = 'flex';
+    if (!wasVisible) {
+      lockBodyScroll();
+    }
     if (dnEntryPreview) {
       dnEntryPreview.innerHTML = '';
     }
@@ -175,7 +179,13 @@ export function createDnEntryManager({
   }
 
   function closeModal() {
-    if (dnModal) dnModal.style.display = 'none';
+    if (dnModal) {
+      const wasVisible = dnModal.style.display === 'flex';
+      dnModal.style.display = 'none';
+      if (wasVisible) {
+        unlockBodyScroll();
+      }
+    }
   }
 
   async function handleConfirm() {

--- a/src/views/admin/setupAdminPage.js
+++ b/src/views/admin/setupAdminPage.js
@@ -14,7 +14,13 @@ import { createLspSummaryCardManager } from './lspSummaryCards.js';
 import { createFilterBridgeManager } from './filterBridgeManager.js';
 import { createAuthHandler } from './authHandler.js';
 import { getTodayDateStringInTimezone } from './dateUtils.js';
-import { escapeHtml, setFormControlValue } from './utils.js';
+import {
+  escapeHtml,
+  setFormControlValue,
+  lockBodyScroll,
+  unlockBodyScroll,
+  resetBodyScrollLock,
+} from './utils.js';
 import { createTableRenderer } from './tableRenderer.js';
 
 import {
@@ -959,11 +965,19 @@ export function setupAdminPage(
     populateModalStatusDeliveryOptions(canonicalStatusDelivery);
     updateModalFieldVisibility();
     if (mMsg) mMsg.textContent = '';
+    const wasVisible = mask && mask.style.display === 'flex';
     if (mask) mask.style.display = 'flex';
+    if (!wasVisible) {
+      lockBodyScroll();
+    }
   }
 
   function closeModal() {
+    const wasVisible = mask && mask.style.display === 'flex';
     if (mask) mask.style.display = 'none';
+    if (wasVisible) {
+      unlockBodyScroll();
+    }
     editingId = 0;
     editingItem = null;
     if (mStatusDelivery) {
@@ -982,8 +996,12 @@ export function setupAdminPage(
       historyContent.innerHTML = '<div class="loading-state" data-i18n="updateHistory.loading">加载中...</div>';
     }
     
+    const wasVisible = updateHistoryModal.style.display === 'flex';
     updateHistoryModal.style.display = 'flex';
-    
+    if (!wasVisible) {
+      lockBodyScroll();
+    }
+
     try {
       const url = `${API_BASE}/api/dn/${encodeURIComponent(dnNumber)}`;
       const resp = await fetch(url, { signal });
@@ -1013,7 +1031,11 @@ export function setupAdminPage(
 
   function closeUpdateHistoryModal() {
     if (updateHistoryModal) {
+      const wasVisible = updateHistoryModal.style.display === 'flex';
       updateHistoryModal.style.display = 'none';
+      if (wasVisible) {
+        unlockBodyScroll();
+      }
     }
   }
 
@@ -1923,5 +1945,6 @@ export function setupAdminPage(
       console.error(err);
     }
     if (tableRenderer) tableRenderer.cleanup();
+    resetBodyScrollLock();
   };
 }

--- a/src/views/admin/utils.js
+++ b/src/views/admin/utils.js
@@ -1,3 +1,6 @@
+const SCROLL_LOCK_CLASS = 'admin-scroll-locked';
+let scrollLockCount = 0;
+
 export function escapeHtml(input) {
   return String(input)
     .replace(/&/g, '&amp;')
@@ -89,4 +92,42 @@ export function normalizeDateControlValue(value) {
     console.error(err);
   }
   return '';
+}
+
+function applyScrollLockClass(target, action) {
+  if (!target || typeof target.classList?.[action] !== 'function') return;
+  try {
+    target.classList[action](SCROLL_LOCK_CLASS);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function setScrollLockClasses(action) {
+  if (typeof document === 'undefined') return;
+  applyScrollLockClass(document.body, action);
+  applyScrollLockClass(document.documentElement, action);
+}
+
+export function lockBodyScroll() {
+  if (typeof document === 'undefined') return;
+  scrollLockCount += 1;
+  if (scrollLockCount === 1) {
+    setScrollLockClasses('add');
+  }
+}
+
+export function unlockBodyScroll() {
+  if (typeof document === 'undefined') return;
+  if (scrollLockCount > 0) {
+    scrollLockCount -= 1;
+  }
+  if (scrollLockCount === 0) {
+    setScrollLockClasses('remove');
+  }
+}
+
+export function resetBodyScrollLock() {
+  scrollLockCount = 0;
+  setScrollLockClasses('remove');
 }


### PR DESCRIPTION
## Summary
- add reusable helpers to lock and unlock body scrolling
- apply scroll locking to admin edit, auth, DN entry, and history modals
- update admin styles to disable page scrolling when a modal is open and reset on cleanup

## Testing
- npm run build *(fails: missing dependencies such as ant-design-vue in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bc0367d88320a0c14fd9ceadf2ec