### PR TITLE
修改 DN 校验规则为 2-5 位字母 + 10-15 位数字

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -1,7 +1,7 @@
 {
   "title": "Local Transport Management System (Indonesia)",
   "dn.label": "DN Number (supports multiple lines/commas/spaces; multiple means batch query)",
-  "dn.tip": "Hint: DN numbers are 14-18 chars. They must start with 3-5 uppercase letters, and the rest are digits.",
+  "dn.tip": "Hint: DN numbers are 2-5 uppercase letters followed by 10-15 digits.",
   "statusDelivery.label": "Delivery Status",
   "statusDelivery.filter.any": "(Any)",
   "statusDelivery.filter.notEmpty": "Any Non-empty",

--- a/public/locales/id/admin.json
+++ b/public/locales/id/admin.json
@@ -6,7 +6,7 @@
   "title": "Manajemen Catatan Pengajuan DN",
   "dn.label": "Nomor DN (mendukung baris/komma/spasi; lebih dari satu = pencarian batch)",
   "dn.placeholder": "Contoh:\nDN123...\nDN456...",
-  "dn.tip": "Petunjuk: Nomor DN harus 14-18 karakter. Harus diawali 3-5 huruf besar, sisanya angka.",
+  "dn.tip": "Petunjuk: Nomor DN harus 2-5 huruf besar diikuti 10-15 angka.",
   "statusDelivery.label": "Status Pengiriman",
   "statusDelivery.filter.any": "(Apa saja)",
   "statusDelivery.filter.notEmpty": "Apa saja (tidak kosong)",

--- a/public/locales/zh/admin.json
+++ b/public/locales/zh/admin.json
@@ -6,7 +6,7 @@
   "title": "DN 提交记录管理",
   "dn.label": "DN 号（支持多行/逗号/空格分隔；多于1个则批量查询）",
   "dn.placeholder": "示例：\nDN123...",
-  "dn.tip": "合法的DN number为 3-5位大写字母+数字，总长为14-18位。",
+  "dn.tip": "合法的DN number为 2-5位大写字母+10-15位数字。",
   "statusDelivery.label": "配送状态",
   "statusDelivery.filter.any": "(任意)",
   "statusDelivery.filter.notEmpty": "任意非空",

--- a/src/utils/dn.js
+++ b/src/utils/dn.js
@@ -1,6 +1,6 @@
 const DN_ZERO_WIDTH_RE = /[\u200B\u200C\u200D\u2060\uFEFF]/g;
-export const DN_VALID_RE = /^[A-Z]{3,5}\d{9,15}$/;
-const DN_VALID_WITH_SUFFIX_RE = /^([A-Z]{3,5}\d{9,15})B\d{2,3}$/;
+export const DN_VALID_RE = /^[A-Z]{2,5}\d{10,15}$/;
+const DN_VALID_WITH_SUFFIX_RE = /^([A-Z]{2,5}\d{10,15})B\d{2,3}$/;
 
 export function normalizeDnSoft(raw) {
   return (raw || '').replace(DN_ZERO_WIDTH_RE, '').toUpperCase();


### PR DESCRIPTION
### Motivation
- 使前端对 DN 的校验规则与新的业务要求保持一致：DN 由 2-5 位大写字母开头，后接 10-15 位数字。
- 保证在带 `Bxx`/`Bxxx` 后缀的归一化场景中也能按新规则提取基础 DN。
- 更新多语言后台提示，以避免提示文本与实际校验不一致。

### Description
- 将核心校验正则由 `^[A-Z]{3,5}\d{9,15}$` 修改为 `^[A-Z]{2,5}\d{10,15}$`（文件：`src/utils/dn.js` 的 `DN_VALID_RE`）。
- 同步更新带后缀的匹配正则由 `^([A-Z]{3,5}\d{9,15})B\d{2,3}$` 到 `^([A-Z]{2,5}\d{10,15})B\d{2,3}$`，以保持 `normalizeDnWithSuffix` 的行为一致（文件：`src/utils/dn.js`）。
- 更新后台页面的多语言提示文本以反映新规则（文件：`public/locales/zh/admin.json`、`public/locales/en/admin.json`、`public/locales/id/admin.json`）。

### Testing
- 执行 `npm run -s lint`，命令以非 0 退出（未通过或项目无可用 lint 脚本）。
- 执行 `npm run -s build`，构建失败，因当前环境缺少 `vite` 可执行文件，未能完成构建验证。
- 未运行其他自动化单元测试或集成测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce3658e088324b2f9368aab137a8b)