### PR TITLE
Show Find SG LPN scan load failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,6 @@ VITE_API_BASE=https://api.example.com
 VITE_DYNAMSOFT_LICENSE_KEY=your-dynamsoft-license
 VITE_MAPBOX_ACCESS_TOKEN=your-mapbox-access-token
 
-# Optional; defaults to `${VITE_API_BASE}/api/find-sg-lpn-infos`.
-VITE_FIND_SG_LPN_URL=
-
 VITE_ROLE_CUSTOMER_USER_01="customer-login|Customer Name|customer-password"
 VITE_ROLE_LSP_USER_01="lsp-login|LSP Name|lsp-password"
 VITE_ROLE_TRANSPORT_MANAGER_USER_01="tm-login|Transport Manager Name|tm-password"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Create a `.env` file (or copy `.env` to `.env.local`) and provide the values app
 VITE_API_BASE=https://api.example.com
 VITE_MAPBOX_ACCESS_TOKEN=pk.your-mapbox-token
 VITE_DYNAMSOFT_LICENSE_KEY=your-dynamsoft-license
-# Optional; defaults to `${VITE_API_BASE}/api/find-sg-lpn-infos`
-VITE_FIND_SG_LPN_URL=
 ```
 
 These variables are read at build time by Vite. Ensure any deployment platform exposes the `VITE_*` variables during the build step so the application can access them at runtime.

--- a/src/services/checkApi.js
+++ b/src/services/checkApi.js
@@ -9,6 +9,13 @@ const extractApiError = (payload, fallback) => {
   return fallback;
 };
 
+const appendRequestContext = (message, { status, url } = {}) => {
+  const parts = [message || 'Request failed'];
+  if (status) parts.push(`status ${status}`);
+  if (url) parts.push(url);
+  return parts.join(' · ');
+};
+
 export async function findSgLpnInfos(orderNumber, options = {}) {
   const trimmedOrderNumber = String(orderNumber || '').trim();
   if (!trimmedOrderNumber) {
@@ -21,13 +28,24 @@ export async function findSgLpnInfos(orderNumber, options = {}) {
     pageNum: Number(options.pageNum || 1),
   };
 
-  const response = await fetch(getFindSgLpnUrl(), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
-    body: JSON.stringify(body),
-  });
+  const requestUrl = getFindSgLpnUrl();
+  let response = null;
+  try {
+    response = await fetch(requestUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new Error(
+      appendRequestContext(
+        `Network request failed: ${err?.message || err}. Check VITE_API_BASE, backend availability, and CORS.`,
+        { url: requestUrl }
+      )
+    );
+  }
 
   let payload = null;
   try {
@@ -37,11 +55,20 @@ export async function findSgLpnInfos(orderNumber, options = {}) {
   }
 
   if (!response.ok) {
-    throw new Error(extractApiError(payload, `HTTP ${response.status}`));
+    throw new Error(
+      appendRequestContext(extractApiError(payload, `HTTP ${response.status}`), {
+        status: response.status,
+        url: requestUrl,
+      })
+    );
   }
 
   if (normalizeApiCode(payload?.code) !== '200') {
-    throw new Error(extractApiError(payload, `API code ${payload?.code ?? 'unknown'}`));
+    throw new Error(
+      appendRequestContext(extractApiError(payload, `API code ${payload?.code ?? 'unknown'}`), {
+        url: requestUrl,
+      })
+    );
   }
 
   if (!Array.isArray(payload?.list)) {

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -38,8 +38,6 @@ export const getDynamsoftLicenseKey = () => {
 };
 
 export const getFindSgLpnUrl = () => {
-  const envValue = readImportMetaEnv('VITE_FIND_SG_LPN_URL');
-  if (envValue) return envValue;
   const apiBase = getApiBase().replace(/\/+$/, '');
   return `${apiBase}/api/find-sg-lpn-infos`;
 };


### PR DESCRIPTION
## Summary
- show Find SG LPN request URL and HTTP status in scan load failures
- include a clearer network-failure hint for backend reachability, VITE_API_BASE, and CORS issues

## Validation
- npm run build
