### PR TITLE
add check result page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,6 @@ VITE_API_BASE=https://api.example.com
 VITE_DYNAMSOFT_LICENSE_KEY=your-dynamsoft-license
 VITE_MAPBOX_ACCESS_TOKEN=your-mapbox-access-token
 
-# Optional; defaults to `${VITE_API_BASE}/api/find-sg-lpn-infos`.
-VITE_FIND_SG_LPN_URL=
-
 VITE_ROLE_CUSTOMER_USER_01="customer-login|Customer Name|customer-password"
 VITE_ROLE_LSP_USER_01="lsp-login|LSP Name|lsp-password"
 VITE_ROLE_TRANSPORT_MANAGER_USER_01="tm-login|Transport Manager Name|tm-password"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Create a `.env` file (or copy `.env` to `.env.local`) and provide the values app
 VITE_API_BASE=https://api.example.com
 VITE_MAPBOX_ACCESS_TOKEN=pk.your-mapbox-token
 VITE_DYNAMSOFT_LICENSE_KEY=your-dynamsoft-license
-# Optional; defaults to `${VITE_API_BASE}/api/find-sg-lpn-infos`
-VITE_FIND_SG_LPN_URL=
 ```
 
 These variables are read at build time by Vite. Ensure any deployment platform exposes the `VITE_*` variables during the build step so the application can access them at runtime.

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,6 +32,11 @@ const routes = [
     component: () => import('../views/CheckView.vue'),
   },
   {
+    path: '/check-result',
+    name: 'check-result',
+    component: () => import('../views/CheckResultView.vue'),
+  },
+  {
     path: '/routes',
     name: 'routes',
     component: () => import('../views/RouteCalculatorView.vue'),

--- a/src/services/checkApi.js
+++ b/src/services/checkApi.js
@@ -9,6 +9,13 @@ const extractApiError = (payload, fallback) => {
   return fallback;
 };
 
+const appendRequestContext = (message, { status, url } = {}) => {
+  const parts = [message || 'Request failed'];
+  if (status) parts.push(`status ${status}`);
+  if (url) parts.push(url);
+  return parts.join(' · ');
+};
+
 export async function findSgLpnInfos(orderNumber, options = {}) {
   const trimmedOrderNumber = String(orderNumber || '').trim();
   if (!trimmedOrderNumber) {
@@ -21,13 +28,24 @@ export async function findSgLpnInfos(orderNumber, options = {}) {
     pageNum: Number(options.pageNum || 1),
   };
 
-  const response = await fetch(getFindSgLpnUrl(), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
-    body: JSON.stringify(body),
-  });
+  const requestUrl = getFindSgLpnUrl();
+  let response = null;
+  try {
+    response = await fetch(requestUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new Error(
+      appendRequestContext(
+        `Network request failed: ${err?.message || err}. Check VITE_API_BASE, backend availability, and CORS.`,
+        { url: requestUrl }
+      )
+    );
+  }
 
   let payload = null;
   try {
@@ -37,11 +55,20 @@ export async function findSgLpnInfos(orderNumber, options = {}) {
   }
 
   if (!response.ok) {
-    throw new Error(extractApiError(payload, `HTTP ${response.status}`));
+    throw new Error(
+      appendRequestContext(extractApiError(payload, `HTTP ${response.status}`), {
+        status: response.status,
+        url: requestUrl,
+      })
+    );
   }
 
   if (normalizeApiCode(payload?.code) !== '200') {
-    throw new Error(extractApiError(payload, `API code ${payload?.code ?? 'unknown'}`));
+    throw new Error(
+      appendRequestContext(extractApiError(payload, `API code ${payload?.code ?? 'unknown'}`), {
+        url: requestUrl,
+      })
+    );
   }
 
   if (!Array.isArray(payload?.list)) {

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -38,8 +38,6 @@ export const getDynamsoftLicenseKey = () => {
 };
 
 export const getFindSgLpnUrl = () => {
-  const envValue = readImportMetaEnv('VITE_FIND_SG_LPN_URL');
-  if (envValue) return envValue;
   const apiBase = getApiBase().replace(/\/+$/, '');
   return `${apiBase}/api/find-sg-lpn-infos`;
 };

--- a/src/views/CheckResultView.vue
+++ b/src/views/CheckResultView.vue
@@ -1,0 +1,594 @@
+<template>
+  <main class="check-result-page">
+    <header class="result-header">
+      <div>
+        <h1>Check Result</h1>
+        <p>Delivery list check records</p>
+      </div>
+      <div class="result-filters">
+        <a-date-picker
+          v-model:value="selectedDate"
+          value-format="YYYY-MM-DD"
+          format="YYYY-MM-DD"
+          :allow-clear="false"
+          :disabled="loading"
+        />
+        <a-button type="primary" :loading="loading" @click="fetchResults">Refresh</a-button>
+      </div>
+    </header>
+
+    <a-alert
+      v-if="error"
+      class="result-alert"
+      type="error"
+      :message="error"
+      show-icon
+      closable
+      @close="error = ''"
+    />
+
+    <section class="summary-strip">
+      <div>
+        <span class="summary-label">Date</span>
+        <strong>{{ selectedDate }}</strong>
+      </div>
+      <div>
+        <span class="summary-label">Records</span>
+        <strong>{{ total }}</strong>
+      </div>
+      <div>
+        <span class="summary-label">Completed</span>
+        <strong>{{ completedCount }}</strong>
+      </div>
+    </section>
+
+    <section class="desktop-table">
+      <a-table
+        :columns="columns"
+        :data-source="items"
+        :loading="loading"
+        :pagination="pagination"
+        row-key="id"
+        size="middle"
+        @change="handleTableChange"
+      >
+        <template #bodyCell="{ column, record }">
+          <template v-if="column.key === 'dn_number'">
+            <button class="link-button" type="button" @click="openDetail(record)">
+              {{ record.dn_number || '-' }}
+            </button>
+          </template>
+          <template v-else-if="column.key === 'progress'">
+            <span class="progress-text">{{ record.checked_count || 0 }}/{{ record.box_count || 0 }}</span>
+          </template>
+          <template v-else-if="column.key === 'status'">
+            <span :class="['status-pill', normalizeStatus(record.status)]">{{ record.status || '-' }}</span>
+          </template>
+          <template v-else-if="column.key === 'action'">
+            <a-button size="small" @click="openDetail(record)">View</a-button>
+          </template>
+        </template>
+      </a-table>
+    </section>
+
+    <section class="mobile-list">
+      <a-spin :spinning="loading">
+        <article v-for="item in items" :key="item.id" class="result-card" @click="openDetail(item)">
+          <div class="card-top">
+            <strong>{{ item.dn_number || '-' }}</strong>
+            <span :class="['status-pill', normalizeStatus(item.status)]">{{ item.status || '-' }}</span>
+          </div>
+          <dl>
+            <div>
+              <dt>LSP</dt>
+              <dd>{{ item.lsp || '-' }}</dd>
+            </div>
+            <div>
+              <dt>Checker</dt>
+              <dd>{{ item.checker_name || '-' }}</dd>
+            </div>
+            <div>
+              <dt>Progress</dt>
+              <dd>{{ item.checked_count || 0 }}/{{ item.box_count || 0 }}</dd>
+            </div>
+            <div>
+              <dt>Check Time</dt>
+              <dd>{{ item.check_time || '-' }}</dd>
+            </div>
+          </dl>
+        </article>
+        <div v-if="!loading && !items.length" class="empty-state">No check result records</div>
+      </a-spin>
+    </section>
+
+    <div v-if="items.length" class="mobile-pager">
+      <a-button :disabled="loading || page <= 1" @click="goPage(page - 1)">Previous</a-button>
+      <span>{{ page }} / {{ totalPages }}</span>
+      <a-button :disabled="loading || page >= totalPages" @click="goPage(page + 1)">Next</a-button>
+    </div>
+
+    <a-modal
+      v-model:open="detailOpen"
+      title="Check Result Detail"
+      :footer="null"
+      width="min(920px, calc(100vw - 32px))"
+      class="check-detail-modal"
+    >
+      <a-spin :spinning="detailLoading">
+        <template v-if="detail">
+          <section class="detail-grid">
+            <div v-for="field in detailFields" :key="field.key" class="detail-field">
+              <span>{{ field.label }}</span>
+              <strong>{{ field.value || '-' }}</strong>
+            </div>
+          </section>
+
+          <section class="box-section">
+            <h2>Boxes</h2>
+            <div class="box-table-wrap">
+              <table class="box-table">
+                <thead>
+                  <tr>
+                    <th>Box No.</th>
+                    <th>Item No.</th>
+                    <th>Description</th>
+                    <th>Qty</th>
+                    <th>Status</th>
+                    <th>Checked At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(box, index) in detailBoxes" :key="`${box.boxNo || box.box_no || 'box'}-${index}`">
+                    <td>{{ box.boxNo || box.box_no || '-' }}</td>
+                    <td>{{ box.itemNo || box.item_no || '-' }}</td>
+                    <td>{{ box.itemDescEn || box.item_desc_en || '-' }}</td>
+                    <td>{{ box.qty || '-' }}</td>
+                    <td>{{ box.status || '-' }}</td>
+                    <td>{{ box.checkedAt || box.checked_at || '-' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div v-if="!detailBoxes.length" class="empty-state compact">No box details</div>
+            </div>
+          </section>
+        </template>
+      </a-spin>
+    </a-modal>
+  </main>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue';
+import { getApiBase } from '../utils/env.js';
+
+const API_BASE = getApiBase().replace(/\/+$/, '');
+
+const loading = ref(false);
+const detailLoading = ref(false);
+const error = ref('');
+const items = ref([]);
+const total = ref(0);
+const page = ref(1);
+const pageSize = ref(20);
+const selectedDate = ref(formatJakartaDate(new Date()));
+const detailOpen = ref(false);
+const detail = ref(null);
+
+const columns = [
+  { title: 'DN Number', dataIndex: 'dn_number', key: 'dn_number', width: 170 },
+  { title: 'LSP', dataIndex: 'lsp', key: 'lsp', width: 140 },
+  { title: 'Checker', dataIndex: 'checker_name', key: 'checker_name', width: 140 },
+  { title: 'Check Time', dataIndex: 'check_time', key: 'check_time', width: 180 },
+  { title: 'Progress', key: 'progress', width: 110 },
+  { title: 'Status', dataIndex: 'status', key: 'status', width: 120 },
+  { title: 'Created At', dataIndex: 'created_at', key: 'created_at', width: 190 },
+  { title: 'Action', key: 'action', width: 90, fixed: 'right' },
+];
+
+const pagination = computed(() => ({
+  current: page.value,
+  pageSize: pageSize.value,
+  total: total.value,
+  showSizeChanger: true,
+  showTotal: (value) => `Total ${value}`,
+}));
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize.value)));
+const completedCount = computed(() => items.value.filter((item) => normalizeStatus(item.status) === 'completed').length);
+const detailBoxes = computed(() => Array.isArray(detail.value?.boxes) ? detail.value.boxes : []);
+const detailFields = computed(() => {
+  const item = detail.value || {};
+  return [
+    { key: 'report_id', label: 'Report ID', value: item.report_id },
+    { key: 'dn_number', label: 'DN Number', value: item.dn_number },
+    { key: 'lsp', label: 'LSP', value: item.lsp },
+    { key: 'checker_name', label: 'Checker', value: item.checker_name },
+    { key: 'check_time', label: 'Check Time', value: item.check_time },
+    { key: 'status', label: 'Status', value: item.status },
+    { key: 'progress', label: 'Progress', value: `${item.checked_count || 0}/${item.box_count || 0}` },
+    { key: 'created_at', label: 'Created At', value: item.created_at },
+  ];
+});
+
+function formatJakartaDate(date) {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Asia/Jakarta',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date);
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${values.year}-${values.month}-${values.day}`;
+  } catch (_) {
+    const pad = (value) => String(value).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  }
+}
+
+function normalizeStatus(value) {
+  const text = String(value || '').trim().toLowerCase();
+  if (text === 'completed') return 'completed';
+  if (text === 'partial') return 'partial';
+  return 'unknown';
+}
+
+function extractError(payload, fallback) {
+  return payload?.detail || payload?.message || payload?.error || fallback;
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  const payload = await res.json().catch(() => null);
+  if (!res.ok || payload?.ok === false) {
+    throw new Error(extractError(payload, `HTTP ${res.status}`));
+  }
+  return payload;
+}
+
+function buildListUrl() {
+  const url = new URL(`${API_BASE}/api/dn/check_result`);
+  url.searchParams.set('date', selectedDate.value);
+  url.searchParams.set('page', String(page.value));
+  url.searchParams.set('page_size', String(pageSize.value));
+  return url.toString();
+}
+
+async function fetchResults() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await fetchJson(buildListUrl());
+    items.value = Array.isArray(payload.items) ? payload.items : [];
+    total.value = Number(payload.total || 0);
+  } catch (err) {
+    error.value = `Failed to load check results: ${err?.message || err}`;
+    items.value = [];
+    total.value = 0;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function openDetail(record) {
+  if (!record?.id) return;
+  detailOpen.value = true;
+  detailLoading.value = true;
+  detail.value = null;
+  try {
+    const payload = await fetchJson(`${API_BASE}/api/dn/check_result/${encodeURIComponent(record.id)}`);
+    detail.value = payload.item || null;
+  } catch (err) {
+    error.value = `Failed to load check result detail: ${err?.message || err}`;
+    detailOpen.value = false;
+  } finally {
+    detailLoading.value = false;
+  }
+}
+
+function handleTableChange(nextPagination) {
+  page.value = Number(nextPagination?.current || 1);
+  pageSize.value = Number(nextPagination?.pageSize || 20);
+  fetchResults();
+}
+
+function goPage(nextPage) {
+  page.value = Math.min(Math.max(1, nextPage), totalPages.value);
+  fetchResults();
+}
+
+watch(selectedDate, () => {
+  page.value = 1;
+  fetchResults();
+});
+
+onMounted(fetchResults);
+</script>
+
+<style scoped>
+.check-result-page {
+  min-height: 100vh;
+  padding: 28px;
+  background: #f5f7fb;
+  color: #172033;
+}
+
+.result-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.result-header h1 {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.result-header p {
+  margin: 6px 0 0;
+  color: #64748b;
+}
+
+.result-filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.result-alert {
+  margin-bottom: 16px;
+}
+
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.summary-strip > div {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.summary-label {
+  display: block;
+  margin-bottom: 4px;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.summary-strip strong {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.desktop-table {
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.link-button {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #1677ff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.progress-text {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.status-pill.completed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-pill.partial {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-pill.unknown {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.mobile-list,
+.mobile-pager {
+  display: none;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.detail-field {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.detail-field span {
+  display: block;
+  margin-bottom: 4px;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.detail-field strong {
+  overflow-wrap: anywhere;
+  font-size: 14px;
+}
+
+.box-section h2 {
+  margin: 0 0 10px;
+  font-size: 16px;
+}
+
+.box-table-wrap {
+  overflow-x: auto;
+}
+
+.box-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.box-table th,
+.box-table td {
+  padding: 10px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  vertical-align: top;
+}
+
+.box-table th {
+  color: #475569;
+  background: #f8fafc;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.empty-state {
+  padding: 28px 16px;
+  color: #64748b;
+  text-align: center;
+}
+
+.empty-state.compact {
+  padding: 14px;
+}
+
+@media (max-width: 760px) {
+  .check-result-page {
+    padding: 16px;
+  }
+
+  .result-header {
+    display: block;
+  }
+
+  .result-header h1 {
+    font-size: 24px;
+  }
+
+  .result-filters {
+    margin-top: 14px;
+  }
+
+  .result-filters :deep(.ant-picker) {
+    flex: 1;
+  }
+
+  .summary-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .summary-strip > div {
+    padding: 12px 10px;
+  }
+
+  .summary-strip strong {
+    font-size: 16px;
+    overflow-wrap: anywhere;
+  }
+
+  .desktop-table {
+    display: none;
+  }
+
+  .mobile-list {
+    display: block;
+  }
+
+  .result-card {
+    padding: 14px;
+    margin-bottom: 10px;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+
+  .card-top strong {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 16px;
+  }
+
+  .result-card dl {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin: 0;
+  }
+
+  .result-card dt {
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .result-card dd {
+    margin: 2px 0 0;
+    overflow-wrap: anywhere;
+    color: #172033;
+    font-size: 13px;
+  }
+
+  .mobile-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 14px;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/CheckView.vue
+++ b/src/views/CheckView.vue
@@ -140,6 +140,10 @@
               Checker Name
               <input ref="checkerNameInput" v-model.trim="checkerName" class="text-input" type="text" autocomplete="name" placeholder="Please enter checker name" @keydown.enter="generatePdfReport" />
             </label>
+            <label class="field-label">
+              LSP
+              <input v-model.trim="reportLsp" class="text-input" type="text" autocomplete="organization" placeholder="LSP" @keydown.enter="generatePdfReport" />
+            </label>
             <div class="report-actions">
               <button class="secondary" type="button" @click="closeReportModal">Cancel</button>
               <button class="primary" type="button" @click="generatePdfReport">Confirm</button>
@@ -158,7 +162,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import { createScanner } from '../composables/useScanner.js';
 import { findSgLpnInfos } from '../services/checkApi.js';
 import { getApiBase } from '../utils/env.js';
@@ -166,6 +170,23 @@ import { getApiBase } from '../utils/env.js';
 const API_BASE = getApiBase();
 const DEDUP_MS = 1200;
 const SCAN_MODE = Object.freeze({ DN: 'dn', BOX: 'box' });
+const CHECKER_NAME_STORAGE_KEY = 'check_report_checker_name';
+const REPORT_LSP_STORAGE_KEY = 'check_report_lsp';
+
+const readStoredValue = (key) => {
+  try {
+    return String(localStorage.getItem(key) || '').trim();
+  } catch (_) {
+    return '';
+  }
+};
+const writeStoredValue = (key, value) => {
+  try {
+    const text = String(value || '').trim();
+    if (text) localStorage.setItem(key, text);
+    else localStorage.removeItem(key);
+  } catch (_) {}
+};
 
 const cameraViewHost = ref(null);
 const checkerNameInput = ref(null);
@@ -173,7 +194,9 @@ const selectedCameraId = ref('');
 const detailModalOpen = ref(false);
 const selectedBoxKey = ref('');
 const reportModalOpen = ref(false);
-const checkerName = ref('');
+
+const checkerName = ref(readStoredValue(CHECKER_NAME_STORAGE_KEY));
+const reportLsp = ref(readStoredValue(REPORT_LSP_STORAGE_KEY));
 const reportFeedback = ref('A PDF report can be generated after all boxes are checked.');
 const reportDownloadUrl = ref('');
 const reportFilename = ref('delivery-list-check-result.pdf');
@@ -238,8 +261,10 @@ const groupedBoxes = computed(() => {
   });
 
   return Array.from(map.values()).sort((a, b) => {
+    const aLastChecked = a.key === state.lastCheckedBoxKey;
+    const bLastChecked = b.key === state.lastCheckedBoxKey;
+    if (aLastChecked !== bLastChecked) return aLastChecked ? -1 : 1;
     if (a.checked !== b.checked) return a.checked ? 1 : -1;
-    if (a.checked && b.checked) return String(b.checkedAt).localeCompare(String(a.checkedAt));
     return a.boxNo.localeCompare(b.boxNo, undefined, { numeric: true, sensitivity: 'base' });
   });
 });
@@ -251,6 +276,9 @@ const selectedBoxSummary = computed(() => {
   if (!selectedBox.value) return '';
   return `${selectedBox.value.rows.length} item${selectedBox.value.rows.length > 1 ? 's' : ''} · ${selectedBox.value.checked ? 'Checked' : 'Pending'}`;
 });
+
+watch(checkerName, (value) => writeStoredValue(CHECKER_NAME_STORAGE_KEY, value));
+watch(reportLsp, (value) => writeStoredValue(REPORT_LSP_STORAGE_KEY, value));
 
 function setPill(kind, text, type = '') {
   if (kind === 'reader') {
@@ -492,6 +520,7 @@ async function handleDnScan(text) {
 
     state.dnNumber = dnNumber;
     state.boxRows = matchedRows;
+    reportLsp.value = matchedRows.find((row) => String(row.lsp || '').trim())?.lsp || readStoredValue(REPORT_LSP_STORAGE_KEY);
     state.lastCheckedBoxKey = '';
     state.recent.clear();
     resetReportDownload();
@@ -529,7 +558,9 @@ function handleBoxScan(text) {
   resetReportDownload();
 
   if (canGenerateReport.value) {
-    setPill('reader', 'DBR: Complete · still scanning', 'ok');
+    void stopScan({ silent: true, keepStatus: true });
+    setPill('reader', 'DBR: Complete', 'ok');
+    setPill('camera', 'Check complete', 'ok');
     showToast(`Box confirmed: ${text}\nAll boxes for this DN have been scanned.`, 'success');
   } else {
     setPill('reader', 'DBR: Scanning next box', 'ok');
@@ -600,7 +631,7 @@ function buildReportPayload(checker) {
   return {
     reportId: generateReportId(),
     dnNumber: state.dnNumber,
-    lsp: state.boxRows[0]?.lsp || '',
+    lsp: reportLsp.value.trim(),
     checkerName: checker,
     checkTime: nowDateTime(),
     boxCount: groupedBoxes.value.length,
@@ -697,6 +728,8 @@ async function generatePdfReport() {
     return;
   }
   try {
+    writeStoredValue(CHECKER_NAME_STORAGE_KEY, checker);
+    writeStoredValue(REPORT_LSP_STORAGE_KEY, reportLsp.value);
     await ensureReportScripts();
   } catch (err) {
     showToast(err?.message || 'Failed to load report dependencies.', 'error');
@@ -724,7 +757,7 @@ async function generatePdfReport() {
     doc.setFontSize(10);
     doc.setTextColor(54, 65, 85);
     doc.text(`DN Number: ${state.dnNumber}`, margin, 78);
-    doc.text(`LSP: ${state.boxRows[0]?.lsp || '-'}`, margin, 96);
+    doc.text(`LSP: ${reportLsp.value.trim() || '-'}`, margin, 96);
     doc.text(`Checker Name: ${checker}`, margin, 114);
     doc.text(`Check Time: ${reportTime}`, margin, 132);
 


### PR DESCRIPTION
## Summary

- Add a responsive `/check-result` page for date-filtered check result list queries and detail viewing.
- Update the check workflow to persist Checker Name and LSP locally, auto-fill LSP from DN box data when present, and include it in generated reports/uploads.
- Keep the latest checked box at the top, group pending boxes before checked boxes, and stop scanning when all boxes are checked.

## Validation

- Not rerun after final changes per request; reviewed the implementation statically.